### PR TITLE
fix: return 401 Unauthorized for invalid login instead of 404

### DIFF
--- a/src/main/java/com/manuelfabri/expenses/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/manuelfabri/expenses/exception/GlobalExceptionHandler.java
@@ -31,9 +31,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(InvalidLoginException.class)
-  @ResponseStatus(value = HttpStatus.NOT_FOUND)
+  @ResponseStatus(value = HttpStatus.UNAUTHORIZED)
   public ResponseEntity<Object> handleInvalidLoginException(InvalidLoginException ex, WebRequest request) {
-    return buildErrorResponse(ex, HttpStatus.NOT_FOUND, request);
+    return buildErrorResponse(ex, HttpStatus.UNAUTHORIZED, request);
   }
 
   @ExceptionHandler(DataIntegrityViolationException.class)


### PR DESCRIPTION
## Summary
- `InvalidLoginException` was incorrectly mapped to HTTP 404 (Not Found) in `GlobalExceptionHandler`
- Changed to HTTP 401 (Unauthorized), which is the correct status for failed authentication attempts
- 404 should be reserved for missing resources, not auth failures

## Test plan
- [x] Attempt login with invalid credentials and verify the response status is 401
- [x] Verify valid login still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)