### PR TITLE
fix(api): generate a recurrence's first occurrence immediately on creation

### DIFF
--- a/src/main/java/com/manuelfabri/expenses/service/implementation/RecurrentTransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/RecurrentTransactionServiceImplementation.java
@@ -1,5 +1,7 @@
 package com.manuelfabri.expenses.service.implementation;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashSet;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +25,7 @@ import com.manuelfabri.expenses.repository.CategoryRepository;
 import com.manuelfabri.expenses.repository.RecurrentTransactionRepository;
 import com.manuelfabri.expenses.repository.SubcategoryRepository;
 import com.manuelfabri.expenses.service.RecurrenceDateCalculator;
+import com.manuelfabri.expenses.service.RecurrentTransactionGeneratorService;
 import com.manuelfabri.expenses.service.RecurrentTransactionService;
 import com.manuelfabri.expenses.service.TransactionRelatedEntities;
 
@@ -33,16 +36,19 @@ public class RecurrentTransactionServiceImplementation implements RecurrentTrans
   private CategoryRepository categoryRepository;
   private SubcategoryRepository subcategoryRepository;
   private RecurrenceDateCalculator dateCalculator;
+  private RecurrentTransactionGeneratorService generatorService;
   private ModelMapper mapper;
 
   public RecurrentTransactionServiceImplementation(RecurrentTransactionRepository recurrentTransactionRepository,
       AccountRepository accountRepository, CategoryRepository categoryRepository,
-      SubcategoryRepository subcategoryRepository, RecurrenceDateCalculator dateCalculator, ModelMapper mapper) {
+      SubcategoryRepository subcategoryRepository, RecurrenceDateCalculator dateCalculator,
+      RecurrentTransactionGeneratorService generatorService, ModelMapper mapper) {
     this.recurrentTransactionRepository = recurrentTransactionRepository;
     this.accountRepository = accountRepository;
     this.categoryRepository = categoryRepository;
     this.subcategoryRepository = subcategoryRepository;
     this.dateCalculator = dateCalculator;
+    this.generatorService = generatorService;
     this.mapper = mapper;
   }
 
@@ -109,6 +115,10 @@ public class RecurrentTransactionServiceImplementation implements RecurrentTrans
     applyRequestToEntity(recurrence, requestDto, entities);
 
     RecurrentTransaction saved = recurrentTransactionRepository.save(recurrence);
+    // The nightly job only picks up occurrences due as of its next run, so without this a
+    // recurrence created today for today (an interval start date, or a monthly day matching
+    // today) wouldn't produce its first transaction until after midnight.
+    generatorService.generateForRecurrence(saved, OffsetDateTime.now(ZoneOffset.UTC).toLocalDate());
     return toDto(saved);
   }
 

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/RecurrentTransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/RecurrentTransactionServiceImplementationTest.java
@@ -3,8 +3,10 @@ package com.manuelfabri.expenses.service.implementation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
@@ -18,6 +20,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
@@ -42,6 +45,7 @@ import com.manuelfabri.expenses.repository.CategoryRepository;
 import com.manuelfabri.expenses.repository.RecurrentTransactionRepository;
 import com.manuelfabri.expenses.repository.SubcategoryRepository;
 import com.manuelfabri.expenses.service.RecurrenceDateCalculator;
+import com.manuelfabri.expenses.service.RecurrentTransactionGeneratorService;
 
 @ExtendWith(MockitoExtension.class)
 class RecurrentTransactionServiceImplementationTest {
@@ -56,6 +60,8 @@ class RecurrentTransactionServiceImplementationTest {
   private SubcategoryRepository subcategoryRepository;
   @Mock
   private RecurrenceDateCalculator dateCalculator;
+  @Mock
+  private RecurrentTransactionGeneratorService generatorService;
 
   private RecurrentTransactionServiceImplementation service;
   private User currentUser;
@@ -70,7 +76,7 @@ class RecurrentTransactionServiceImplementationTest {
         .setSkipNullEnabled(true);
 
     service = new RecurrentTransactionServiceImplementation(recurrentTransactionRepository, accountRepository,
-        categoryRepository, subcategoryRepository, dateCalculator, mapper);
+        categoryRepository, subcategoryRepository, dateCalculator, generatorService, mapper);
 
     currentUser = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
     account = new Account(10L, "Checking", CurrencyEnum.USD, currentUser);
@@ -218,6 +224,37 @@ class RecurrentTransactionServiceImplementationTest {
 
     assertThat(result.getIntervalDays()).isNull();
     assertThat(result.getDaysOfMonth()).containsExactlyInAnyOrder(1, 15);
+  }
+
+  @Test
+  void create_immediatelyAsksTheGeneratorToBackfillTodaysOccurrence() {
+    RecurrentTransactionRequestDto requestDto = intervalRequestDto();
+    stubRelatedEntities();
+    when(dateCalculator.nextDueDate(any())).thenReturn(Optional.empty());
+    when(recurrentTransactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.create(requestDto);
+
+    ArgumentCaptor<RecurrentTransaction> recurrenceCaptor = ArgumentCaptor.forClass(RecurrentTransaction.class);
+    verify(generatorService).generateForRecurrence(recurrenceCaptor.capture(), eq(LocalDate.now(ZoneOffset.UTC)));
+    assertThat(recurrenceCaptor.getValue().getDescription()).isEqualTo("Streaming subscription");
+  }
+
+  @Test
+  void update_doesNotAskTheGeneratorToBackfillAnything() {
+    RecurrentTransaction existingRecurrence = new RecurrentTransaction();
+    existingRecurrence.setId(1L);
+    existingRecurrence.setOwner(currentUser);
+    existingRecurrence.setStatus(RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingRecurrence));
+    RecurrentTransactionRequestDto requestDto = intervalRequestDto();
+    stubRelatedEntities();
+    when(dateCalculator.nextDueDate(any())).thenReturn(Optional.empty());
+    when(recurrentTransactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.update(1L, requestDto);
+
+    verifyNoInteractions(generatorService);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Creating a recurring transaction due today (an interval recurrence starting today, or a monthly recurrence whose configured day matches today) previously wouldn't produce its first `Transaction` row until the nightly `00:05` scheduled job ran - `RecurrenceDateCalculator` computed "today" correctly, but nothing invoked it until then.
- `RecurrentTransactionServiceImplementation.create()` now calls `RecurrentTransactionGeneratorService.generateForRecurrence(saved, today)` right after saving, so an already-due first occurrence is backfilled synchronously as part of the create request.
- The generator is already a safe no-op when nothing is due yet, so this can be called unconditionally on every create without special-casing frequency/start date.

## Test plan
- [x] `RecurrentTransactionServiceImplementationTest`: new test asserts `create()` invokes the generator with the just-saved recurrence and today's date; another asserts `update()` does not (only creation should backfill).
- [x] Full `mvn verify` (tests + JaCoCo coverage gate) passes locally.
- [x] Manually create a recurring EXPENSE with "every X days" starting today, and a MONTHLY_DAYS recurrence with today's day-of-month selected - confirm both produce a transaction immediately, visible in the same request/response cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)