### PR TITLE
fix(api): production readiness - Spring Boot upgrade, config fixes, security, observability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,8 @@ target/
 *.iml
 .idea/
 .git
+.github/
+.vscode/
+.env
+.env.*
+docker-compose.yml

--- a/.github/workflows/cd-merges-develop.yml
+++ b/.github/workflows/cd-merges-develop.yml
@@ -33,13 +33,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Create .env file
-        run: |
-          echo "PROFILE=dev" >> .env
-          echo "FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY_DEV }}" >> .env
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_DEV }}" >> .env
-          echo "DECRYPT_KEY=${{ secrets.DECRYPT_KEY }}" >> .env
-
       - name: Set short SHA
         id: sha
         run: echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
@@ -52,8 +45,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/expensapp-api:beta
             ${{ secrets.DOCKER_HUB_USERNAME }}/expensapp-api:beta-${{ steps.sha.outputs.short_sha }}
-          build-args: |
-            PROFILE=dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/cd-merges-main.yml
+++ b/.github/workflows/cd-merges-main.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image (Development)
+name: Build and Push Docker Image (Production)
 
 on:
   push:
@@ -32,13 +32,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Create .env file
-        run: |
-          echo "PROFILE=prod" >> .env
-          echo "FIREBASE_API_KEY=${{ secrets.FIREBASE_API_KEY }}" >> .env
-          echo "GOOGLE_APPLICATION_CREDENTIALS=${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}" >> .env
-          echo "DECRYPT_KEY=${{ secrets.DECRYPT_KEY }}" >> .env
 
       - name: Set up git credentials
         run: |
@@ -82,8 +75,6 @@ jobs:
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/expensapp-api:latest
             ${{ secrets.DOCKER_HUB_USERNAME }}/expensapp-api:${{ steps.get_version.outputs.version }}
-          build-args: |
-            PROFILE=dev
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.12</version>
+		<version>3.5.16</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.manuelfabri</groupId>
@@ -16,7 +16,7 @@
 	<description>Expenses REST Api</description>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2022.0.3</spring-cloud.version>
+		<spring-cloud.version>2025.0.3</spring-cloud.version>
 	</properties>
 	<dependencies>
 
@@ -58,6 +58,15 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-bootstrap</artifactId>
+		</dependency>
+		<!-- Required for spring.cloud.config.fail-fast's retry loop (bootstrap.yml) to actually run -->
+		<dependency>
+			<groupId>org.springframework.retry</groupId>
+			<artifactId>spring-retry</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -108,6 +117,11 @@
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
 			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.9.0</version>
 		</dependency>
 	</dependencies>
 	<dependencyManagement>

--- a/src/main/java/com/manuelfabri/expenses/config/SecurityConfig.java
+++ b/src/main/java/com/manuelfabri/expenses/config/SecurityConfig.java
@@ -3,8 +3,12 @@ package com.manuelfabri.expenses.config;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.info.InfoEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -52,13 +56,31 @@ public class SecurityConfig {
     return source;
   }
 
+  /**
+   * Actuator gets its own chain, evaluated before {@link #filterChain}, so infra health checks
+   * (Railway, load balancers) never need a Firebase token. Only health/info are exposed at all (see
+   * management.endpoints.web.exposure.include); any other actuator endpoint added later still falls
+   * back to requiring an authenticated user, same as the rest of the app.
+   */
   @Bean
+  @Order(1)
+  SecurityFilterChain actuatorSecurityFilterChain(HttpSecurity http) throws Exception {
+    http.securityMatcher(EndpointRequest.toAnyEndpoint()).csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests((authz) -> authz.requestMatchers(EndpointRequest.to(HealthEndpoint.class, InfoEndpoint.class))
+            .permitAll().anyRequest().authenticated());
+    return http.build();
+  }
+
+  @Bean
+  @Order(2)
   SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     String authRouteMatcher = Urls.AUTH + "/**";
+    String apiDocsRouteMatcher = Urls.API_DOCS + "/**";
+    String swaggerUiRouteMatcher = Urls.SWAGGER_UI + "/**";
 
     return http.csrf(csrf -> csrf.disable()).cors(cors -> cors.configurationSource(corsConfigurationSource()))
-        .authorizeHttpRequests(
-            (authz) -> authz.requestMatchers(authRouteMatcher).permitAll().anyRequest().authenticated())
+        .authorizeHttpRequests((authz) -> authz.requestMatchers(authRouteMatcher, apiDocsRouteMatcher, swaggerUiRouteMatcher)
+            .permitAll().anyRequest().authenticated())
         .addFilterBefore(new FirebaseAuthorizationFilter(userService, firebaseService),
             UsernamePasswordAuthenticationFilter.class)
         .sessionManagement(sess -> sess.sessionCreationPolicy(SessionCreationPolicy.STATELESS)).build();

--- a/src/main/java/com/manuelfabri/expenses/constants/Urls.java
+++ b/src/main/java/com/manuelfabri/expenses/constants/Urls.java
@@ -13,4 +13,8 @@ public final class Urls {
   public static final String SUBCATEGORY = "/subcategory";
   public static final String SUMMARY = "/summary";
   public static final String RECURRENT_TRANSACTION = "/recurrent-transaction";
+
+  // springdoc-openapi's default paths
+  public static final String API_DOCS = "/v3/api-docs";
+  public static final String SWAGGER_UI = "/swagger-ui";
 }

--- a/src/main/java/com/manuelfabri/expenses/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/manuelfabri/expenses/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.manuelfabri.expenses.exception;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -17,6 +19,8 @@ import com.manuelfabri.expenses.dto.ErrorResponseDto;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
   @ExceptionHandler(ResourceNotFoundException.class)
   @ResponseStatus(value = HttpStatus.NOT_FOUND)
@@ -54,6 +58,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
       HttpStatusCode status, WebRequest request) {
     return buildErrorResponse(ex, "Validation error. Check 'errors' field for details.",
         HttpStatus.UNPROCESSABLE_ENTITY, request, ex.getBindingResult().getFieldErrors());
+  }
+
+  /**
+   * Catch-all for any exception type not handled above. Without this, an unmapped exception falls
+   * through to Spring's default BasicErrorController - a different response shape than every other
+   * error in this API, and never logged.
+   */
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(value = HttpStatus.INTERNAL_SERVER_ERROR)
+  public ResponseEntity<Object> handleUnexpectedException(Exception ex, WebRequest request) {
+    LOGGER.error("Unhandled exception", ex);
+    return buildErrorResponse(ex, "An unexpected error occurred.", HttpStatus.INTERNAL_SERVER_ERROR, request, null);
   }
 
   /**

--- a/src/main/java/com/manuelfabri/expenses/filter/FirebaseAuthorizationFilter.java
+++ b/src/main/java/com/manuelfabri/expenses/filter/FirebaseAuthorizationFilter.java
@@ -1,5 +1,7 @@
 package com.manuelfabri.expenses.filter;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -22,6 +24,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
 public class FirebaseAuthorizationFilter extends OncePerRequestFilter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FirebaseAuthorizationFilter.class);
   private static final String HEADER_NAME = "Authorization";
 
   private FirebaseService firebaseService;
@@ -40,8 +43,9 @@ public class FirebaseAuthorizationFilter extends OncePerRequestFilter {
     String xAuth = request.getHeader(HEADER_NAME);
     String requestURI = request.getRequestURI();
 
-    // Bypass /auth URLs
-    if (requestURI.startsWith(Urls.AUTH)) {
+    // Bypass /auth and springdoc's OpenAPI/Swagger UI URLs
+    if (requestURI.startsWith(Urls.AUTH) || requestURI.startsWith(Urls.API_DOCS)
+        || requestURI.startsWith(Urls.SWAGGER_UI)) {
       filterChain.doFilter(request, response);
       return;
     }
@@ -68,7 +72,9 @@ public class FirebaseAuthorizationFilter extends OncePerRequestFilter {
       return;
     } catch (Exception e) {
       SecurityContextHolder.clearContext();
-      throw new ServletException(e.getMessage());
+      LOGGER.error("Unexpected error while authorizing request", e);
+      writeErrorResponse(response, HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "An unexpected error occurred.");
+      return;
     }
 
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,26 +7,27 @@ spring:
     name: expensapp
   # JPA Properties
   jpa:
+    # Liquibase (below) owns all schema changes; Hibernate only verifies the entities match what
+    # Liquibase already migrated. This was previously set as spring.jpa.properties.hibernate.ddl-auto,
+    # which Hibernate does not recognize (its native key is hibernate.hbm2ddl.auto) - so it was a no-op
+    # and the app was silently running on Spring Boot's implicit default the whole time.
+    hibernate:
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
-        # Hibernate ddl auto (create, create-drop, validate, update)
-        # CREATE: Cada vez que se inicia la app, crea la tabla
-        # CREATE-DROP: Cada vez que se inicia la app, crea la tabla y cuando se detiene la borra
-        # VALIDATE: A revisar.
-        # UPDATE: Crea la tabla si no existe, pero si existe la actualiza
-        ddl-auto: update
         naming:
           physical-strategy: org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy
           implicit-strategy: org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy
+  # Was previously nested under server.liquibase, which Spring Boot does not bind (correct prefix is
+  # spring.liquibase) - another no-op that happened to match Liquibase's own defaults.
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml
+    enabled: true
 
 server:
   tomcat:
     max-threads: 50
-
-  liquibase:
-    change-log: classpath:db/changelog/db.changelog-master.yaml
-    enabled: true
   # security:
   #   oauth2:
   #     resourceserver:
@@ -35,3 +36,18 @@ server:
 firebase:
   admin-sdk-path: ${GOOGLE_APPLICATION_CREDENTIALS}
   api-key: ${FIREBASE_API_KEY}
+
+# Explicit rather than relying on Spring Boot's implicit default (also health+info, but undocumented
+# here); SecurityConfig's actuatorSecurityFilterChain permits these two publicly for infra health checks.
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+
+logging:
+  level:
+    root: INFO
+    com.manuelfabri.expenses: INFO
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n"

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -3,5 +3,15 @@ spring:
     config:
       uri:
         - https://configserver.manuelfabri.com/
+      # Previously, a transient config-server blip meant the client logged a warning and continued
+      # booting on local-only defaults (fail-fast's actual default) - silently missing every
+      # per-environment override. fail-fast=true + retry (below) make that failure loud and retried
+      # instead of silent.
+      fail-fast: true
+      retry:
+        max-attempts: 6
+        initial-interval: 1000
+        multiplier: 1.1
+        max-interval: 2000
 encrypt:
   key: ${DECRYPT_KEY}

--- a/src/test/java/com/manuelfabri/expenses/config/SecurityConfigTest.java
+++ b/src/test/java/com/manuelfabri/expenses/config/SecurityConfigTest.java
@@ -1,0 +1,49 @@
+package com.manuelfabri.expenses.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.auth.FirebaseAuth;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Exercises the real security filter chains (both {@link SecurityConfig} beans, plus
+ * {@link com.manuelfabri.expenses.filter.FirebaseAuthorizationFilter}) end to end, unlike the
+ * controller slice tests which disable security filters entirely. FirebaseApp/FirebaseAuth are
+ * mocked out - the real beans need actual Google service-account credentials, which this test
+ * doesn't need since it never calls Firebase.
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private FirebaseApp firebaseApp;
+
+  @MockitoBean
+  private FirebaseAuth firebaseAuth;
+
+  @Test
+  void actuatorHealth_isPubliclyAccessible_withoutAuthentication() throws Exception {
+    mockMvc.perform(get("/actuator/health")).andExpect(status().isOk());
+  }
+
+  @Test
+  void apiDocs_isPubliclyAccessible_withoutAuthentication() throws Exception {
+    mockMvc.perform(get("/v3/api-docs")).andExpect(status().isOk());
+  }
+
+  @Test
+  void protectedEndpoint_withoutAuthorizationHeader_returnsUnauthorized() throws Exception {
+    mockMvc.perform(get("/transaction")).andExpect(status().isUnauthorized());
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/manuelfabri/expenses/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,24 @@
+package com.manuelfabri.expenses.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
+import com.manuelfabri.expenses.dto.ErrorResponseDto;
+
+class GlobalExceptionHandlerTest {
+
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+  @Test
+  void handleUnexpectedException_returnsInternalServerErrorWithGenericMessage() {
+    ResponseEntity<Object> response =
+        handler.handleUnexpectedException(new IllegalStateException("boom"), mock(WebRequest.class));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(((ErrorResponseDto) response.getBody()).getMessage()).isEqualTo("An unexpected error occurred.");
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/filter/FirebaseAuthorizationFilterTest.java
+++ b/src/test/java/com/manuelfabri/expenses/filter/FirebaseAuthorizationFilterTest.java
@@ -1,0 +1,61 @@
+package com.manuelfabri.expenses.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.FilterChain;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import com.manuelfabri.expenses.service.FirebaseService;
+import com.manuelfabri.expenses.service.UserService;
+
+class FirebaseAuthorizationFilterTest {
+
+  private final UserService userService = mock(UserService.class);
+  private final FirebaseService firebaseService = mock(FirebaseService.class);
+  private final FirebaseAuthorizationFilter filter = new FirebaseAuthorizationFilter(userService, firebaseService);
+
+  @Test
+  void doFilterInternal_bypassesAuthorization_forApiDocsPath() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/v3/api-docs");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(firebaseService, never()).parseToken(any());
+  }
+
+  @Test
+  void doFilterInternal_bypassesAuthorization_forSwaggerUiPath() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/swagger-ui/index.html");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    verify(filterChain).doFilter(request, response);
+    verify(firebaseService, never()).parseToken(any());
+  }
+
+  @Test
+  void doFilterInternal_unexpectedException_writesInternalServerErrorJson() throws Exception {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/transaction");
+    request.addHeader("Authorization", "Bearer some-token");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = mock(FilterChain.class);
+    when(firebaseService.parseToken("Bearer some-token")).thenThrow(new RuntimeException("firebase is down"));
+
+    filter.doFilterInternal(request, response, filterChain);
+
+    assertThat(response.getStatus()).isEqualTo(500);
+    assertThat(response.getContentAsString()).contains("An unexpected error occurred.");
+    verify(filterChain, never()).doFilter(any(), any());
+  }
+}


### PR DESCRIPTION
## Summary

Backend equivalent of the frontend production-readiness pass (expensapp-web #23), audited against current Spring Boot best practices.

- **Upgrade Spring Boot 3.1.12 -> 3.5.16** (EOL, no more security patches) and Spring Cloud 2022.0.3 -> 2025.0.3 to match.
- **Fix `ddl-auto`**: it was set at `spring.jpa.properties.hibernate.ddl-auto`, which Hibernate doesn't recognize (native key is `hibernate.hbm2ddl.auto`) — a silent no-op the whole time. Same bug in `server.liquibase.*` (wrong prefix, should be `spring.liquibase.*`). Both corrected; `ddl-auto` now explicit at `validate` so Liquibase stays the sole schema authority.
- **Give actuator its own security chain**, ordered before the app's, so infra health checks don't need a Firebase token. Only `health`/`info` are exposed, explicitly rather than relying on Spring Boot's implicit default.
- **Add a catch-all exception handler** so unmapped exceptions get a consistent, logged JSON error response instead of falling through to Spring's default error controller.
- **Fix `FirebaseAuthorizationFilter`'s unexpected-exception branch**, which broke its own documented JSON-error contract by rethrowing as a bare `ServletException`.
- **Add baseline logging config** (levels + pattern).
- **Add springdoc-openapi** for live OpenAPI/Swagger docs at `/v3/api-docs` and `/swagger-ui`.
- **Make Spring Cloud Config failures loud** (`fail-fast` + retry) instead of silently booting on local-only defaults after a config-server blip.
- **Fix CD workflow**: `cd-merges-main.yml` was titled "(Development)" despite deploying prod, and both CD workflows wrote a `.env` file / `build-args: PROFILE=...` that the `Dockerfile` never consumes — removed the dead steps, fixed the title.
- Extended `.dockerignore`.

## Risk notes

- `ddl-auto: validate` is now actually enforced for the first time (previously inert). If entity mappings have silently drifted from the real schema, this will surface as a startup failure where it previously wouldn't have. Worth watching on the `dev` deploy before this reaches `main`.
- `spring.cloud.config.fail-fast: true` means a config-server outage is now a hard, retried failure instead of a silent degraded boot — this also applies to local dev per the README (`local` profile still talks to the real config server).

## Test plan

- [x] `mvn clean verify` — 66/66 tests pass (7 new: `SecurityConfigTest`, `GlobalExceptionHandlerTest`, `FirebaseAuthorizationFilterTest`)
- [x] `SecurityConfigTest` boots the real security chains end-to-end: `/actuator/health` public, `/v3/api-docs` public, `/transaction` 401s without auth
- [x] Diff coverage gate: 100%
- [ ] Not verified live (no Docker in this environment) — confirm on the `dev` deploy: actuator/swagger reachability, `ddl-auto: validate` against the real Liquibase-migrated schema, config-server retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)