### PR TITLE
ci(api): sync version-bump git-credentials fix from main

### DIFF
--- a/.github/workflows/cd-merges-main.yml
+++ b/.github/workflows/cd-merges-main.yml
@@ -111,6 +111,9 @@ jobs:
         run: |
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@github.com'
+          # main requires a PR for changes; the default GITHUB_TOKEN (github-actions[bot]) can't
+          # bypass that. GH_PAT (also used by the build job's tag push) belongs to an admin, who can.
+          git remote set-url origin https://x-access-token:${{ secrets.GH_PAT }}@github.com/${{ github.repository }}
           git add pom.xml
           git commit -m "Bump version after release [skip ci]" || echo "No changes to commit"
           git push


### PR DESCRIPTION
## Summary

Brings the same one-line fix from #31 into `develop`'s copy of `cd-merges-main.yml`, so the next `develop` -> `main` promotion doesn't conflict with or silently revert the hotfix. This workflow only triggers on push to `main`, so the change has no runtime effect on `develop` itself — it's purely to keep the two copies of the file from drifting.

See #31 for the actual root cause/fix explanation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)