### PR TITLE
ci(api): sync tag-based versioning redesign from develop

### DIFF
--- a/.github/workflows/cd-merges-main.yml
+++ b/.github/workflows/cd-merges-main.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   build:
@@ -41,25 +42,27 @@ jobs:
 
       - name: Determine release version
         id: get_version
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          BRANCH_NAME="${GITHUB_REF#refs/heads/}"
-          if [ -n "$GITHUB_HEAD_REF" ]; then
-            BRANCH_NAME="$GITHUB_HEAD_REF"
-          fi
-          BRANCH_NAME_LC=$(echo "$BRANCH_NAME" | tr '[:upper:]' '[:lower:]')
-          if [[ $BRANCH_NAME_LC =~ ^(fix|bugfix|hotfix)[/\-] ]]; then
-            LAST_TAG=$(git tag --sort=-v:refname | grep -E '^([0-9]+\.[0-9]+\.[0-9]+)$' | head -n1)
-            MAJOR=$(echo $LAST_TAG | cut -d. -f1)
-            MINOR=$(echo $LAST_TAG | cut -d. -f2)
-            PATCH=$(echo $LAST_TAG | cut -d. -f3)
-            NEW_PATCH=$((PATCH+1))
-            VERSION="$MAJOR.$MINOR.$NEW_PATCH"
-            echo "version=$VERSION" >> $GITHUB_OUTPUT
+          LAST_TAG=$(git tag --sort=-v:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n1)
+          MAJOR=$(echo "$LAST_TAG" | cut -d. -f1)
+          MINOR=$(echo "$LAST_TAG" | cut -d. -f2)
+          PATCH=$(echo "$LAST_TAG" | cut -d. -f3)
+
+          # Source branch of the PR that produced this push to main. Uses the "associated pull
+          # requests" API rather than $GITHUB_HEAD_REF (always empty on a push event, only ever set
+          # for pull_request events) or parsing the commit message (breaks on squash/rebase merges,
+          # which this repo also uses - see the "(#29)"-style commit for an example).
+          SOURCE_BRANCH=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0].head.ref // empty')
+          SOURCE_BRANCH_LC=$(echo "$SOURCE_BRANCH" | tr '[:upper:]' '[:lower:]')
+
+          if [[ "$SOURCE_BRANCH_LC" =~ ^(fix|bugfix|hotfix)[/-] ]]; then
+            VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
           else
-            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-            VERSION_NO_SNAPSHOT=${VERSION/-SNAPSHOT/}
-            echo "version=$VERSION_NO_SNAPSHOT" >> $GITHUB_OUTPUT
+            VERSION="$MAJOR.$((MINOR + 1)).0"
           fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Create git tag for release version
         run: |
@@ -88,29 +91,3 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: railway redeploy -y --service=${{ env.SVC_ID }}
-
-  version:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - name: Bump version in pom.xml to next -SNAPSHOT
-        if: github.ref == 'refs/heads/main' && !startsWith(github.head_ref, 'fix') && !startsWith(github.head_ref, 'bugfix') && !startsWith(github.head_ref, 'hotfix')
-        run: |
-          VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          VERSION_NO_SNAPSHOT=${VERSION/-SNAPSHOT/}
-          MAJOR=$(echo $VERSION_NO_SNAPSHOT | cut -d. -f1)
-          MINOR=$(echo $VERSION_NO_SNAPSHOT | cut -d. -f2)
-          NEW_MINOR=$((MINOR+1))
-          NEW_VERSION="$MAJOR.$NEW_MINOR.0-SNAPSHOT"
-          mvn versions:set -DnewVersion=$NEW_VERSION
-          mvn versions:commit
-
-      - name: Commit and push bumped version
-        if: github.ref == 'refs/heads/main' && !startsWith(github.head_ref, 'fix') && !startsWith(github.head_ref, 'bugfix') && !startsWith(github.head_ref, 'hotfix')
-        run: |
-          git config --global user.name 'github-actions'
-          git config --global user.email 'github-actions@github.com'
-          git add pom.xml
-          git commit -m "Bump version after release [skip ci]" || echo "No changes to commit"
-          git push

--- a/README.md
+++ b/README.md
@@ -220,7 +220,14 @@ Three GitHub Actions workflows:
 | ---------------------------- | --------------------------------- | --------------------------------------------------------------------------------- |
 | `ci-build-test.yml`         | PR → `main` or `develop`         | `mvn verify` (build + test), uploads the JaCoCo report as an artifact and to Codecov |
 | `cd-merges-develop.yml`     | Push → `develop`                 | Builds a `beta`-tagged Docker image, pushes to Docker Hub, redeploys the `dev` Railway environment |
-| `cd-merges-main.yml`        | Push → `main`                    | Builds a versioned Docker image, pushes to Docker Hub, tags the release in git, redeploys the production Railway environment, bumps `pom.xml` to the next `-SNAPSHOT` version |
+| `cd-merges-main.yml`        | Push → `main`                    | Builds a versioned Docker image, pushes to Docker Hub, tags the release in git, redeploys the production Railway environment |
+
+Release versioning is computed entirely from git tags at release time - `pom.xml`'s `<version>` is not used for
+this. `cd-merges-main.yml` looks up the PR that produced the push to `main` (via GitHub's "associated pull
+requests" API, so it works regardless of merge/squash/rebase strategy): a `fix/`, `bugfix/`, or `hotfix/` branch
+bumps the patch version, anything else (the normal `develop` → `main` flow) bumps the minor version and resets
+patch to `0`. Major versions are bumped manually/ad hoc (create and push the tag yourself) when there's a
+breaking API change - the next automated release then builds on top of whatever the latest tag is.
 
 Both `cd-*` workflows deploy the same Railway service (`expensapp-api`) but to different Railway *environments*
 (`dev` vs. production) — each needs its own environment-scoped `RAILWAY_TOKEN_DEV`/`RAILWAY_TOKEN` secret, since

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,11 @@
 	</parent>
 	<groupId>com.manuelfabri</groupId>
 	<artifactId>expenses</artifactId>
-	<version>1.10.0-SNAPSHOT</version>
+	<!-- Not the release version - that's tracked entirely via git tags, computed at release time in
+	     cd-merges-main.yml (minor bump on develop merges, patch bump on hotfix merges, major bumps
+	     are manual/ad hoc). This field isn't consumed by anything at runtime; left static so nothing
+	     implies it's meaningful. -->
+	<version>0.0.0-SNAPSHOT</version>
 	<name>Expenses App API</name>
 	<description>Expenses REST Api</description>
 	<properties>


### PR DESCRIPTION
## Summary

Brings the same changes as #33 into `develop`'s copies of `cd-merges-main.yml`, `pom.xml`, and `README.md`, so the next `develop` → `main` promotion doesn't conflict with or revert them. The workflow file only triggers on push to `main`, so this change has no runtime effect on `develop` itself — purely keeps the files from drifting.

Supersedes #32 (closed as superseded — it patched the `version` job's credentials, but #33 removes that job entirely).

See #33 for the full rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)