### PR TITLE
ci(api): fetch full tag history so version computation can see tags

### DIFF
--- a/.github/workflows/cd-merges-main.yml
+++ b/.github/workflows/cd-merges-main.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth: 0 is required for "Determine release version" below to see existing tags -
+      # actions/checkout's default is a shallow, tag-less clone (fetch-tags: true alone doesn't
+      # reliably fix this - see https://github.com/actions/checkout/issues/1781).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary

The run right after #33 merged failed:

\`\`\`
##[group]Run VERSION=.1.0
fatal: '.1.0' is not a valid tag name.
\`\`\`

\`MAJOR\`/\`MINOR\` came out empty because \`git tag --sort=-v:refname | grep ... | head -n1\` found nothing - \`actions/checkout@v4\` defaults to a shallow, tag-less clone. Confirmed via GitHub's own known issue: \`fetch-tags: true\` alone isn't reliable either, \`fetch-depth: 0\` is the documented fix ([actions/checkout#1781](https://github.com/actions/checkout/issues/1781)).

This bug existed the whole time in #33's design, just masked: the *old* script's tag-reading branch (the hotfix path) was dead code that never actually executed (branch detection via \`$GITHUB_HEAD_REF\` never fires on a \`push\` event), so nothing had ever exercised \`git tag --sort=...\` in this job before #33 made it unconditional.

## Fix

Add \`fetch-depth: 0\` to the \`build\` job's \`actions/checkout@v4\` step.

## Test plan

- [x] YAML validated
- [x] Simulated the bash logic locally against the repo's real tags (with full history fetched): correctly computes \`2.3.0\` off the current latest tag \`2.2.0\`
- [ ] Confirm the next push to \`main\` tags correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)