### PR TITLE
ci(api): sync checkout fetch-depth fix from main

### DIFF
--- a/.github/workflows/cd-merges-main.yml
+++ b/.github/workflows/cd-merges-main.yml
@@ -13,7 +13,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      # fetch-depth: 0 is required for "Determine release version" below to see existing tags -
+      # actions/checkout's default is a shallow, tag-less clone (fetch-tags: true alone doesn't
+      # reliably fix this - see https://github.com/actions/checkout/issues/1781).
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Summary

Syncs #37 into develop's copy of \`cd-merges-main.yml\`. Inert on develop itself (this workflow only triggers on push to main) - purely keeps the file from drifting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)