### PR TITLE
feat(user-settings): persist theme and locale preferences per user

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,3 +130,9 @@
   a PR, not just in CI. No `package.json`/npm involved — it's a plain script, activated once per clone via
   `git config core.hooksPath .githooks` (see the README's Getting Started section). Node.js is only needed to run
   the script itself.
+- Passing the 80% gate is not the goal — 100% line coverage on new/changed files is. The pre-push hook and Codecov
+  both only fail below 80%, so it's easy to open a PR that's "green" while still leaving boilerplate uncovered
+  (a no-arg constructor, a setter, a controller method, an `if` branch only ever exercised one way). Before pushing,
+  check `target/site/jacoco/jacoco.xml` (or the Codecov PR comment once it posts) for the files you touched and add
+  the missing case rather than accepting the gap — see the `feat/persist-user-settings` PRs
+  (expensapp-api#40 / expensapp-web#26) for an example of closing exactly this kind of gap after the fact.

--- a/src/main/java/com/manuelfabri/expenses/constants/Urls.java
+++ b/src/main/java/com/manuelfabri/expenses/constants/Urls.java
@@ -13,6 +13,7 @@ public final class Urls {
   public static final String SUBCATEGORY = "/subcategory";
   public static final String SUMMARY = "/summary";
   public static final String RECURRENT_TRANSACTION = "/recurrent-transaction";
+  public static final String USER_SETTINGS = "/user-settings";
 
   // springdoc-openapi's default paths
   public static final String API_DOCS = "/v3/api-docs";

--- a/src/main/java/com/manuelfabri/expenses/controller/UserSettingsController.java
+++ b/src/main/java/com/manuelfabri/expenses/controller/UserSettingsController.java
@@ -1,0 +1,35 @@
+package com.manuelfabri.expenses.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.manuelfabri.expenses.constants.Urls;
+import com.manuelfabri.expenses.dto.UserSettingsDto;
+import com.manuelfabri.expenses.dto.UserSettingsRequestDto;
+import com.manuelfabri.expenses.service.UserSettingsService;
+
+@RestController
+@RequestMapping(Urls.USER_SETTINGS)
+public class UserSettingsController {
+
+  private UserSettingsService userSettingsService;
+
+  public UserSettingsController(UserSettingsService userSettingsService) {
+    this.userSettingsService = userSettingsService;
+  }
+
+  @GetMapping
+  public ResponseEntity<UserSettingsDto> getSettings() {
+    return new ResponseEntity<>(userSettingsService.getSettings(), HttpStatus.OK);
+  }
+
+  @PatchMapping
+  public ResponseEntity<UserSettingsDto> updateSettings(@RequestBody UserSettingsRequestDto userSettingsDto) {
+    return new ResponseEntity<>(userSettingsService.updateSettings(userSettingsDto), HttpStatus.OK);
+  }
+
+}

--- a/src/main/java/com/manuelfabri/expenses/dto/UserSettingsDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/UserSettingsDto.java
@@ -1,0 +1,14 @@
+package com.manuelfabri.expenses.dto;
+
+import com.manuelfabri.expenses.model.ThemeEnum;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class UserSettingsDto {
+
+  @NotNull
+  private ThemeEnum theme;
+  @NotNull
+  private String locale;
+}

--- a/src/main/java/com/manuelfabri/expenses/dto/UserSettingsRequestDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/UserSettingsRequestDto.java
@@ -1,0 +1,11 @@
+package com.manuelfabri.expenses.dto;
+
+import com.manuelfabri.expenses.model.ThemeEnum;
+import lombok.Data;
+
+@Data
+public class UserSettingsRequestDto {
+
+  private ThemeEnum theme;
+  private String locale;
+}

--- a/src/main/java/com/manuelfabri/expenses/model/ThemeEnum.java
+++ b/src/main/java/com/manuelfabri/expenses/model/ThemeEnum.java
@@ -1,0 +1,8 @@
+package com.manuelfabri.expenses.model;
+
+/**
+ * The {@code ThemeEnum} handles constants for the supported UI theme preferences
+ */
+public enum ThemeEnum {
+  SYSTEM, LIGHT, DARK;
+}

--- a/src/main/java/com/manuelfabri/expenses/model/UserSettings.java
+++ b/src/main/java/com/manuelfabri/expenses/model/UserSettings.java
@@ -1,0 +1,53 @@
+package com.manuelfabri.expenses.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+
+@Entity(name = "usersettings")
+public class UserSettings {
+
+  @Id
+  @Column(name = "userid")
+  private String userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 20)
+  private ThemeEnum theme = ThemeEnum.SYSTEM;
+
+  @Column(nullable = false, length = 10)
+  private String locale = "en";
+
+  public UserSettings() {}
+
+  public UserSettings(String userId) {
+    this.userId = userId;
+  }
+
+  public String getUserId() {
+    return userId;
+  }
+
+  public void setUserId(String userId) {
+    this.userId = userId;
+  }
+
+  public ThemeEnum getTheme() {
+    return theme;
+  }
+
+  public void setTheme(ThemeEnum theme) {
+    this.theme = theme;
+  }
+
+  public String getLocale() {
+    return locale;
+  }
+
+  public void setLocale(String locale) {
+    this.locale = locale;
+  }
+
+}

--- a/src/main/java/com/manuelfabri/expenses/repository/UserSettingsRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/UserSettingsRepository.java
@@ -1,0 +1,8 @@
+package com.manuelfabri.expenses.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.manuelfabri.expenses.model.UserSettings;
+
+public interface UserSettingsRepository extends JpaRepository<UserSettings, String> {
+}

--- a/src/main/java/com/manuelfabri/expenses/service/UserSettingsService.java
+++ b/src/main/java/com/manuelfabri/expenses/service/UserSettingsService.java
@@ -1,0 +1,12 @@
+package com.manuelfabri.expenses.service;
+
+import com.manuelfabri.expenses.dto.UserSettingsDto;
+import com.manuelfabri.expenses.dto.UserSettingsRequestDto;
+
+public interface UserSettingsService {
+
+  UserSettingsDto getSettings();
+
+  UserSettingsDto updateSettings(UserSettingsRequestDto userSettingsDto);
+
+}

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementation.java
@@ -1,0 +1,55 @@
+package com.manuelfabri.expenses.service.implementation;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import com.manuelfabri.expenses.dto.UserSettingsDto;
+import com.manuelfabri.expenses.dto.UserSettingsRequestDto;
+import com.manuelfabri.expenses.model.ThemeEnum;
+import com.manuelfabri.expenses.model.User;
+import com.manuelfabri.expenses.model.UserSettings;
+import com.manuelfabri.expenses.repository.UserSettingsRepository;
+import com.manuelfabri.expenses.service.UserSettingsService;
+
+@Service
+public class UserSettingsServiceImplementation implements UserSettingsService {
+
+  private UserSettingsRepository userSettingsRepository;
+  private ModelMapper mapper;
+
+  public UserSettingsServiceImplementation(UserSettingsRepository userSettingsRepository, ModelMapper mapper) {
+    this.userSettingsRepository = userSettingsRepository;
+    this.mapper = mapper;
+  }
+
+  private String getCurrentUserId() {
+    User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    return user.getId();
+  }
+
+  @Override
+  public UserSettingsDto getSettings() {
+    UserSettings settings = this.userSettingsRepository.findById(getCurrentUserId())
+        .orElseGet(() -> new UserSettings(getCurrentUserId()));
+
+    return mapper.map(settings, UserSettingsDto.class);
+  }
+
+  @Override
+  public UserSettingsDto updateSettings(UserSettingsRequestDto userSettingsDto) {
+    String userId = getCurrentUserId();
+    UserSettings settings = this.userSettingsRepository.findById(userId).orElseGet(() -> new UserSettings(userId));
+
+    if (userSettingsDto.getTheme() != null) {
+      settings.setTheme(userSettingsDto.getTheme());
+    }
+    if (userSettingsDto.getLocale() != null) {
+      settings.setLocale(userSettingsDto.getLocale());
+    }
+
+    UserSettings updatedSettings = this.userSettingsRepository.save(settings);
+
+    return mapper.map(updatedSettings, UserSettingsDto.class);
+  }
+
+}

--- a/src/main/resources/db/changelog/9-add-user-settings.yaml
+++ b/src/main/resources/db/changelog/9-add-user-settings.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 9-1-create-usersettings-table
+      author: manufabri91
+      comment: "Create user settings table"
+      changes:
+        - createTable:
+            tableName: usersettings
+            columns:
+              - column:
+                  constraints:
+                    nullable: false
+                    primaryKey: true
+                  name: userid
+                  type: VARCHAR(255)
+              - column:
+                  constraints:
+                    nullable: false
+                  name: theme
+                  type: VARCHAR(20)
+                  defaultValue: SYSTEM
+              - column:
+                  constraints:
+                    nullable: false
+                  name: locale
+                  type: VARCHAR(10)
+                  defaultValue: en
+
+  - changeSet:
+      id: 9-2-create-usersettings-fk
+      author: manufabri91
+      comment: "Create FK for user settings"
+      changes:
+        - addForeignKeyConstraint:
+            baseColumnNames: userid
+            baseTableName: usersettings
+            constraintName: FK_usersettings_user
+            onDelete: CASCADE
+            onUpdate: RESTRICT
+            referencedColumnNames: id
+            referencedTableName: users
+            validate: true

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -17,3 +17,5 @@ databaseChangeLog:
       file: db/changelog/7-fix-enum-storage-to-string.yaml
   - include:
       file: db/changelog/8-add-recurrent-transactions.yaml
+  - include:
+      file: db/changelog/9-add-user-settings.yaml

--- a/src/test/java/com/manuelfabri/expenses/controller/UserSettingsControllerTest.java
+++ b/src/test/java/com/manuelfabri/expenses/controller/UserSettingsControllerTest.java
@@ -1,0 +1,63 @@
+package com.manuelfabri.expenses.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.manuelfabri.expenses.dto.UserSettingsDto;
+import com.manuelfabri.expenses.dto.UserSettingsRequestDto;
+import com.manuelfabri.expenses.model.ThemeEnum;
+import com.manuelfabri.expenses.service.UserSettingsService;
+
+@WebMvcTest(controllers = UserSettingsController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class UserSettingsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockBean
+  private UserSettingsService userSettingsService;
+
+  private UserSettingsDto sampleDto(ThemeEnum theme, String locale) {
+    UserSettingsDto dto = new UserSettingsDto();
+    dto.setTheme(theme);
+    dto.setLocale(locale);
+    return dto;
+  }
+
+  @Test
+  void getSettings_returnsOkWithTheServiceResult() throws Exception {
+    when(userSettingsService.getSettings()).thenReturn(sampleDto(ThemeEnum.SYSTEM, "en"));
+
+    mockMvc.perform(get("/user-settings")).andExpect(status().isOk()).andExpect(jsonPath("$.theme").value("SYSTEM"))
+        .andExpect(jsonPath("$.locale").value("en"));
+  }
+
+  @Test
+  void updateSettings_returnsOkWithTheUpdatedSettings() throws Exception {
+    when(userSettingsService.updateSettings(any())).thenReturn(sampleDto(ThemeEnum.DARK, "es-AR"));
+
+    UserSettingsRequestDto requestDto = new UserSettingsRequestDto();
+    requestDto.setTheme(ThemeEnum.DARK);
+    requestDto.setLocale("es-AR");
+
+    mockMvc
+        .perform(patch("/user-settings").contentType("application/json")
+            .content(objectMapper.writeValueAsString(requestDto)))
+        .andExpect(status().isOk()).andExpect(jsonPath("$.theme").value("DARK"))
+        .andExpect(jsonPath("$.locale").value("es-AR"));
+  }
+
+}

--- a/src/test/java/com/manuelfabri/expenses/model/UserSettingsTest.java
+++ b/src/test/java/com/manuelfabri/expenses/model/UserSettingsTest.java
@@ -1,0 +1,27 @@
+package com.manuelfabri.expenses.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class UserSettingsTest {
+
+  @Test
+  void noArgConstructor_defaultsToSystemThemeAndEnglishLocale() {
+    UserSettings settings = new UserSettings();
+
+    assertThat(settings.getUserId()).isNull();
+    assertThat(settings.getTheme()).isEqualTo(ThemeEnum.SYSTEM);
+    assertThat(settings.getLocale()).isEqualTo("en");
+  }
+
+  @Test
+  void setUserId_updatesTheUserId() {
+    UserSettings settings = new UserSettings();
+
+    settings.setUserId("owner-1");
+
+    assertThat(settings.getUserId()).isEqualTo("owner-1");
+  }
+
+}

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementationTest.java
@@ -1,0 +1,116 @@
+package com.manuelfabri.expenses.service.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.modelmapper.ModelMapper;
+import org.modelmapper.config.Configuration.AccessLevel;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.manuelfabri.expenses.dto.UserSettingsDto;
+import com.manuelfabri.expenses.dto.UserSettingsRequestDto;
+import com.manuelfabri.expenses.model.ThemeEnum;
+import com.manuelfabri.expenses.model.User;
+import com.manuelfabri.expenses.model.UserSettings;
+import com.manuelfabri.expenses.repository.UserSettingsRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserSettingsServiceImplementationTest {
+
+  @Mock
+  private UserSettingsRepository userSettingsRepository;
+
+  private UserSettingsServiceImplementation service;
+  private User currentUser;
+
+  @BeforeEach
+  void setUp() {
+    ModelMapper mapper = new ModelMapper();
+    mapper.getConfiguration().setFieldMatchingEnabled(true).setFieldAccessLevel(AccessLevel.PRIVATE)
+        .setSkipNullEnabled(true);
+
+    service = new UserSettingsServiceImplementation(userSettingsRepository, mapper);
+
+    currentUser = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
+
+    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(currentUser, null));
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void getSettingsReturnsDefaultsWhenNoRowExistsForTheCurrentUser() {
+    when(userSettingsRepository.findById("owner-1")).thenReturn(Optional.empty());
+
+    UserSettingsDto result = service.getSettings();
+
+    assertThat(result.getTheme()).isEqualTo(ThemeEnum.SYSTEM);
+    assertThat(result.getLocale()).isEqualTo("en");
+  }
+
+  @Test
+  void getSettingsReturnsThePersistedRowForTheCurrentUser() {
+    UserSettings existing = new UserSettings("owner-1");
+    existing.setTheme(ThemeEnum.DARK);
+    existing.setLocale("es");
+    when(userSettingsRepository.findById("owner-1")).thenReturn(Optional.of(existing));
+
+    UserSettingsDto result = service.getSettings();
+
+    assertThat(result.getTheme()).isEqualTo(ThemeEnum.DARK);
+    assertThat(result.getLocale()).isEqualTo("es");
+  }
+
+  @Test
+  void updateSettingsCreatesARowWhenNoneExistsYet() {
+    when(userSettingsRepository.findById("owner-1")).thenReturn(Optional.empty());
+    when(userSettingsRepository.save(any(UserSettings.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserSettingsRequestDto request = new UserSettingsRequestDto();
+    request.setTheme(ThemeEnum.DARK);
+    request.setLocale("es-AR");
+
+    UserSettingsDto result = service.updateSettings(request);
+
+    ArgumentCaptor<UserSettings> captor = ArgumentCaptor.forClass(UserSettings.class);
+    verify(userSettingsRepository).save(captor.capture());
+    assertThat(captor.getValue().getUserId()).isEqualTo("owner-1");
+    assertThat(result.getTheme()).isEqualTo(ThemeEnum.DARK);
+    assertThat(result.getLocale()).isEqualTo("es-AR");
+  }
+
+  @Test
+  void updateSettingsOnlyChangesFieldsThatArePresentOnTheRequest() {
+    UserSettings existing = new UserSettings("owner-1");
+    existing.setTheme(ThemeEnum.LIGHT);
+    existing.setLocale("en");
+    when(userSettingsRepository.findById("owner-1")).thenReturn(Optional.of(existing));
+    when(userSettingsRepository.save(any(UserSettings.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserSettingsRequestDto request = new UserSettingsRequestDto();
+    request.setTheme(ThemeEnum.DARK);
+
+    UserSettingsDto result = service.updateSettings(request);
+
+    assertThat(result.getTheme()).isEqualTo(ThemeEnum.DARK);
+    assertThat(result.getLocale()).isEqualTo("en");
+  }
+
+}

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/UserSettingsServiceImplementationTest.java
@@ -113,4 +113,21 @@ class UserSettingsServiceImplementationTest {
     assertThat(result.getLocale()).isEqualTo("en");
   }
 
+  @Test
+  void updateSettingsWithOnlyLocaleProvided_leavesThePersistedThemeUnchanged() {
+    UserSettings existing = new UserSettings("owner-1");
+    existing.setTheme(ThemeEnum.LIGHT);
+    existing.setLocale("en");
+    when(userSettingsRepository.findById("owner-1")).thenReturn(Optional.of(existing));
+    when(userSettingsRepository.save(any(UserSettings.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    UserSettingsRequestDto request = new UserSettingsRequestDto();
+    request.setLocale("es-AR");
+
+    UserSettingsDto result = service.updateSettings(request);
+
+    assertThat(result.getTheme()).isEqualTo(ThemeEnum.LIGHT);
+    assertThat(result.getLocale()).isEqualTo("es-AR");
+  }
+
 }


### PR DESCRIPTION
## Summary
- Adds a `usersettings` table (1:1 with `users`, cascade-deleted with the user) via a new Liquibase changeset.
- New `GET /user-settings` (returns defaults `SYSTEM`/`en` when no row exists yet) and `PATCH /user-settings` (partial upsert) endpoints, scoped to the authenticated user via `SecurityContextHolder`, mirroring the existing `Account`/`User` service/controller patterns.
- Companion frontend PR: manufabri91/expensapp-web#26

## Test plan
- [x] `mvnw test` (full suite) passes, including 4 new `UserSettingsServiceImplementationTest` cases
- [x] `mvnw compile` / `test-compile` clean
- [ ] Manual: run locally, confirm Liquibase applies `9-add-user-settings.yaml`, hit `GET`/`PATCH /user-settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)