### PR TITLE
feat: upcoming/pending transactions + account balance fixes

### DIFF
--- a/src/main/java/com/manuelfabri/expenses/controller/SummaryController.java
+++ b/src/main/java/com/manuelfabri/expenses/controller/SummaryController.java
@@ -14,19 +14,25 @@ import com.manuelfabri.expenses.constants.Urls;
 import com.manuelfabri.expenses.dto.BalanceSummaryDto;
 import com.manuelfabri.expenses.dto.CategoryTotalsDto;
 import com.manuelfabri.expenses.dto.MonthlyBalanceSummaryDto;
+import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionsResponseDto;
 import com.manuelfabri.expenses.model.CurrencyEnum;
 import com.manuelfabri.expenses.service.SummaryService;
 import com.manuelfabri.expenses.service.TransactionStatisticsService;
+import com.manuelfabri.expenses.service.UpcomingTransactionService;
 
 @RestController
 @RequestMapping(Urls.SUMMARY)
 public class SummaryController {
   private SummaryService summaryService;
   private TransactionStatisticsService transactionStatisticsService;
+  private UpcomingTransactionService upcomingTransactionService;
 
-  public SummaryController(SummaryService summaryService, TransactionStatisticsService transactionStatisticsService) {
+  public SummaryController(SummaryService summaryService, TransactionStatisticsService transactionStatisticsService,
+      UpcomingTransactionService upcomingTransactionService) {
     this.summaryService = summaryService;
     this.transactionStatisticsService = transactionStatisticsService;
+    this.upcomingTransactionService = upcomingTransactionService;
   }
 
   @GetMapping
@@ -86,6 +92,16 @@ public class SummaryController {
   @GetMapping("/monthly-history/{months}")
   public ResponseEntity<List<MonthlyBalanceSummaryDto>> getMonthlyHistory(@PathVariable int months) {
     return new ResponseEntity<>(transactionStatisticsService.getMonthlyHistory(months), HttpStatus.OK);
+  }
+
+  @GetMapping("/upcoming-transactions")
+  public ResponseEntity<UpcomingTransactionsResponseDto> getUpcomingTransactions() {
+    return new ResponseEntity<>(upcomingTransactionService.getUpcomingTransactions(), HttpStatus.OK);
+  }
+
+  @GetMapping("/programmed-transactions")
+  public ResponseEntity<ProgrammedTransactionsDto> getProgrammedTransactions() {
+    return new ResponseEntity<>(upcomingTransactionService.getProgrammedTransactions(), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/manuelfabri/expenses/controller/SummaryController.java
+++ b/src/main/java/com/manuelfabri/expenses/controller/SummaryController.java
@@ -90,8 +90,10 @@ public class SummaryController {
   }
 
   @GetMapping("/monthly-history/{months}")
-  public ResponseEntity<List<MonthlyBalanceSummaryDto>> getMonthlyHistory(@PathVariable int months) {
-    return new ResponseEntity<>(transactionStatisticsService.getMonthlyHistory(months), HttpStatus.OK);
+  public ResponseEntity<List<MonthlyBalanceSummaryDto>> getMonthlyHistory(@PathVariable int months,
+      @RequestParam(defaultValue = "false") boolean includePending) {
+    return new ResponseEntity<>(transactionStatisticsService.getMonthlyHistory(months, includePending),
+        HttpStatus.OK);
   }
 
   @GetMapping("/upcoming-transactions")

--- a/src/main/java/com/manuelfabri/expenses/controller/TransactionController.java
+++ b/src/main/java/com/manuelfabri/expenses/controller/TransactionController.java
@@ -11,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -65,6 +66,11 @@ public class TransactionController {
         minAmount, maxAmount, fromDate, toDate), HttpStatus.OK);
   }
 
+  @GetMapping("/pending")
+  public ResponseEntity<List<TransactionDto>> getPendingTransactions() {
+    return new ResponseEntity<>(transactionService.getPendingTransactions(), HttpStatus.OK);
+  }
+
   @GetMapping("/{year}/{month}")
   public ResponseEntity<List<TransactionDto>> getByYearAndMonth(@PathVariable int year, @PathVariable int month) {
     return new ResponseEntity<>(transactionService.getMonthlyTransactions(year, month), HttpStatus.OK);
@@ -90,6 +96,11 @@ public class TransactionController {
   public ResponseEntity<TransactionDto> deleteTransaction(@PathVariable Long id) {
     transactionService.deleteTransaction(id);
     return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @PatchMapping("/{id}/confirm")
+  public ResponseEntity<TransactionDto> confirm(@PathVariable Long id) {
+    return new ResponseEntity<>(transactionService.confirm(id), HttpStatus.OK);
   }
 
 }

--- a/src/main/java/com/manuelfabri/expenses/dto/ProgrammedTransactionsDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/ProgrammedTransactionsDto.java
@@ -1,0 +1,10 @@
+package com.manuelfabri.expenses.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class ProgrammedTransactionsDto {
+  private List<UpcomingTransactionItemDto> expenses;
+  private List<UpcomingTransactionItemDto> incomes;
+}

--- a/src/main/java/com/manuelfabri/expenses/dto/TransactionDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/TransactionDto.java
@@ -32,4 +32,5 @@ public class TransactionDto {
   private SubcategoryDto subcategory;
   private LinkedTransactionDTO linkedTransaction;
   private boolean excludeFromTotals = false;
+  private boolean pending = false;
 }

--- a/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionGroupDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionGroupDto.java
@@ -1,0 +1,12 @@
+package com.manuelfabri.expenses.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingTransactionGroupDto {
+  private String currency;
+  private BigDecimal total;
+  private List<UpcomingTransactionItemDto> items;
+}

--- a/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionItemDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionItemDto.java
@@ -1,0 +1,23 @@
+package com.manuelfabri.expenses.dto;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Set;
+import com.manuelfabri.expenses.model.RecurrenceFrequencyEnum;
+import com.manuelfabri.expenses.model.SourceTypeEnum;
+import lombok.Data;
+
+@Data
+public class UpcomingTransactionItemDto {
+  private SourceTypeEnum sourceType;
+  private Long sourceId;
+  private OffsetDateTime date;
+  private String description;
+  private String categoryIconName;
+  private String categoryColor;
+  private Long accountId;
+  private BigDecimal signedAmount;
+  private RecurrenceFrequencyEnum frequency;
+  private Integer intervalDays;
+  private Set<Integer> daysOfMonth;
+}

--- a/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionsResponseDto.java
+++ b/src/main/java/com/manuelfabri/expenses/dto/UpcomingTransactionsResponseDto.java
@@ -1,0 +1,10 @@
+package com.manuelfabri.expenses.dto;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class UpcomingTransactionsResponseDto {
+  private List<UpcomingTransactionGroupDto> expenses;
+  private List<UpcomingTransactionGroupDto> incomes;
+}

--- a/src/main/java/com/manuelfabri/expenses/model/Account.java
+++ b/src/main/java/com/manuelfabri/expenses/model/Account.java
@@ -31,10 +31,10 @@ public class Account extends BaseEntity {
   private CurrencyEnum currency;
   @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<Transaction> transactions;
-  @Column(nullable = false, precision = 10, scale = 2)
+  @Column(nullable = false, precision = 10, scale = 2, name = "initialbalance")
   private BigDecimal initialBalance = BigDecimal.ZERO;
 
-  @Formula("(SELECT COALESCE(SUM(t.amount), 0) FROM transactions t WHERE t.accountid = id) + initialbalance")
+  @Formula("(SELECT COALESCE(SUM(t.amount), 0) FROM transactions t WHERE t.accountid = id AND t.deleted = false AND t.excludefromtotals = false) + initialbalance")
   private BigDecimal accountBalance;
 
   public Account(Long id, String name, CurrencyEnum currency, User owner) {

--- a/src/main/java/com/manuelfabri/expenses/model/Account.java
+++ b/src/main/java/com/manuelfabri/expenses/model/Account.java
@@ -34,7 +34,7 @@ public class Account extends BaseEntity {
   @Column(nullable = false, precision = 10, scale = 2, name = "initialbalance")
   private BigDecimal initialBalance = BigDecimal.ZERO;
 
-  @Formula("(SELECT COALESCE(SUM(t.amount), 0) FROM transactions t WHERE t.accountid = id AND t.deleted = false AND t.excludefromtotals = false) + initialbalance")
+  @Formula("(SELECT COALESCE(SUM(t.amount), 0) FROM transactions t WHERE t.accountid = id AND t.deleted = false AND t.pending = false) + initialbalance")
   private BigDecimal accountBalance;
 
   public Account(Long id, String name, CurrencyEnum currency, User owner) {

--- a/src/main/java/com/manuelfabri/expenses/model/SourceTypeEnum.java
+++ b/src/main/java/com/manuelfabri/expenses/model/SourceTypeEnum.java
@@ -1,0 +1,8 @@
+package com.manuelfabri.expenses.model;
+
+/**
+ * The {@code SourceTypeEnum} handles constants for where an upcoming/programmed transaction item originates from.
+ */
+public enum SourceTypeEnum {
+  RECURRING, ONE_TIME;
+}

--- a/src/main/java/com/manuelfabri/expenses/model/Transaction.java
+++ b/src/main/java/com/manuelfabri/expenses/model/Transaction.java
@@ -40,7 +40,7 @@ public class Transaction extends BaseEntity {
   @ManyToOne
   @JoinColumn(name = "subcategory")
   private Subcategory subcategory;
-  @Column(nullable = false)
+  @Column(nullable = false, name = "excludefromtotals")
   private boolean excludeFromTotals = false;
   @Column(nullable = false)
   private boolean pending = false;

--- a/src/main/java/com/manuelfabri/expenses/model/Transaction.java
+++ b/src/main/java/com/manuelfabri/expenses/model/Transaction.java
@@ -42,6 +42,8 @@ public class Transaction extends BaseEntity {
   private Subcategory subcategory;
   @Column(nullable = false)
   private boolean excludeFromTotals = false;
+  @Column(nullable = false)
+  private boolean pending = false;
 
   // CONSTRUCTORS
   public Transaction() {}
@@ -142,5 +144,13 @@ public class Transaction extends BaseEntity {
 
   public void setExcludeFromTotals(boolean excludeFromTotals) {
     this.excludeFromTotals = excludeFromTotals;
+  }
+
+  public boolean getPending() {
+    return pending;
+  }
+
+  public void setPending(boolean pending) {
+    this.pending = pending;
   }
 }

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -21,9 +21,6 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
 
   List<Transaction> findByOwnerAndSubcategoryAndDeletedFalse(User user, Subcategory subcategory);
 
-  List<Transaction> findByOwnerAndEventDateBetweenAndDeletedFalse(User user, OffsetDateTime dateStart,
-      OffsetDateTime dateEnd);
-
   List<Transaction> findByOwnerAndEventDateBetweenAndPendingFalseAndDeletedFalse(User owner,
       OffsetDateTime dateStart, OffsetDateTime dateEnd);
 

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -31,7 +31,7 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
 
   @Modifying
   @Transactional
-  @Query("update #{#entityName} t set t.pending = false, t.excludeFromTotals = false where t.pending = true and t.eventDate <= ?1")
+  @Query("update #{#entityName} t set t.pending = false, t.excludeFromTotals = false where t.pending = true and t.eventDate <= ?1 and t.deleted = false")
   void activateDuePendingTransactions(OffsetDateTime asOf);
 
   @Query("SELECT t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND t.amount > 0 and t.owner.id = ?#{ principal?.id } GROUP BY t.account.currency")

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -81,4 +81,10 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
 
   @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND t.amount < 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
   List<Object[]> getTransactionsTotalExpensesByMonth(@Param("fromDate") OffsetDateTime fromDate);
+
+  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount > 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
+  List<Object[]> getTransactionsTotalIncomesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate);
+
+  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount < 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
+  List<Object[]> getTransactionsTotalExpensesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate);
 }

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -82,9 +82,11 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
   @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND t.amount < 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
   List<Object[]> getTransactionsTotalExpensesByMonth(@Param("fromDate") OffsetDateTime fromDate);
 
-  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount > 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
-  List<Object[]> getTransactionsTotalIncomesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate);
+  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount > 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate AND t.eventDate <= :toDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
+  List<Object[]> getTransactionsTotalIncomesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate,
+      @Param("toDate") OffsetDateTime toDate);
 
-  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount < 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
-  List<Object[]> getTransactionsTotalExpensesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate);
+  @Query("SELECT EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND (t.excludeFromTotals = false OR t.pending = true) AND t.amount < 0 AND t.owner.id = ?#{ principal?.id } AND t.eventDate >= :fromDate AND t.eventDate <= :toDate GROUP BY EXTRACT(YEAR FROM t.eventDate), EXTRACT(MONTH FROM t.eventDate), t.account.currency")
+  List<Object[]> getTransactionsTotalExpensesByMonthIncludingPending(@Param("fromDate") OffsetDateTime fromDate,
+      @Param("toDate") OffsetDateTime toDate);
 }

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -2,8 +2,10 @@ package com.manuelfabri.expenses.repository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 import com.manuelfabri.expenses.model.Account;
 import com.manuelfabri.expenses.model.Category;
 import com.manuelfabri.expenses.model.Subcategory;
@@ -21,6 +23,19 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
 
   List<Transaction> findByOwnerAndEventDateBetweenAndDeletedFalse(User user, OffsetDateTime dateStart,
       OffsetDateTime dateEnd);
+
+  List<Transaction> findByOwnerAndEventDateBetweenAndPendingFalseAndDeletedFalse(User owner,
+      OffsetDateTime dateStart, OffsetDateTime dateEnd);
+
+  List<Transaction> findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(User owner, OffsetDateTime dateStart,
+      OffsetDateTime dateEnd);
+
+  List<Transaction> findByOwnerAndPendingTrueAndDeletedFalse(User owner);
+
+  @Modifying
+  @Transactional
+  @Query("update #{#entityName} t set t.pending = false, t.excludeFromTotals = false where t.pending = true and t.eventDate <= ?1")
+  void activateDuePendingTransactions(OffsetDateTime asOf);
 
   @Query("SELECT t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND t.amount > 0 and t.owner.id = ?#{ principal?.id } GROUP BY t.account.currency")
   List<Object[]> getTransactionsTotalIncomes();

--- a/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
+++ b/src/main/java/com/manuelfabri/expenses/repository/TransactionRepository.java
@@ -52,9 +52,6 @@ public interface TransactionRepository extends BaseEntityRepository<Transaction>
   @Query("SELECT t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND EXTRACT(MONTH FROM t.eventDate) = :month AND EXTRACT(YEAR FROM t.eventDate) = :year AND t.amount < 0 and t.owner.id = ?#{ principal?.id } GROUP BY t.account.currency")
   List<Object[]> getTransactionsTotalExpenses(@Param("year") int year, @Param("month") int month);
 
-  @Query("SELECT t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND t.owner.id = ?#{ principal?.id } GROUP BY t.account.currency")
-  List<Object[]> getBalancesByCurrency();
-
   @Query("SELECT t.account.currency, SUM(t.amount) FROM #{#entityName} t WHERE t.deleted = false AND t.excludeFromTotals = false AND EXTRACT(YEAR FROM t.eventDate) = :year AND t.owner.id = ?#{ principal?.id } GROUP BY t.account.currency")
   List<Object[]> getBalancesByCurrency(@Param("year") int year);
 

--- a/src/main/java/com/manuelfabri/expenses/service/PendingTransactionActivationService.java
+++ b/src/main/java/com/manuelfabri/expenses/service/PendingTransactionActivationService.java
@@ -1,0 +1,22 @@
+package com.manuelfabri.expenses.service;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import com.manuelfabri.expenses.repository.TransactionRepository;
+
+@Service
+public class PendingTransactionActivationService {
+  private TransactionRepository transactionRepository;
+
+  public PendingTransactionActivationService(TransactionRepository transactionRepository) {
+    this.transactionRepository = transactionRepository;
+  }
+
+  // TODO: add a distributed lock (e.g. ShedLock) if this app is ever deployed across more than one instance.
+  @Scheduled(cron = "0 10 0 * * *")
+  public void activateDueTransactions() {
+    transactionRepository.activateDuePendingTransactions(OffsetDateTime.now(ZoneOffset.UTC));
+  }
+}

--- a/src/main/java/com/manuelfabri/expenses/service/TransactionService.java
+++ b/src/main/java/com/manuelfabri/expenses/service/TransactionService.java
@@ -18,6 +18,10 @@ public interface TransactionService {
 
   void deleteTransaction(Long id);
 
+  TransactionDto confirm(Long id);
+
+  List<TransactionDto> getPendingTransactions();
+
   Page<TransactionDto> getPagedTransactions(TransactionTypeEnum type, List<Long> categoryIds,
       List<Long> subcategoryIds, List<Long> accountIds, BigDecimal minAmount, BigDecimal maxAmount,
       OffsetDateTime fromDate, OffsetDateTime toDate, Pageable pageable);

--- a/src/main/java/com/manuelfabri/expenses/service/TransactionStatisticsService.java
+++ b/src/main/java/com/manuelfabri/expenses/service/TransactionStatisticsService.java
@@ -34,4 +34,6 @@ public interface TransactionStatisticsService {
   List<CategoryTotalsDto> getTotalsPerCategory(int year, int month);
 
   List<MonthlyBalanceSummaryDto> getMonthlyHistory(int months);
+
+  List<MonthlyBalanceSummaryDto> getMonthlyHistory(int months, boolean includePending);
 }

--- a/src/main/java/com/manuelfabri/expenses/service/UpcomingTransactionService.java
+++ b/src/main/java/com/manuelfabri/expenses/service/UpcomingTransactionService.java
@@ -1,0 +1,10 @@
+package com.manuelfabri.expenses.service;
+
+import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionsResponseDto;
+
+public interface UpcomingTransactionService {
+  UpcomingTransactionsResponseDto getUpcomingTransactions();
+
+  ProgrammedTransactionsDto getProgrammedTransactions();
+}

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementation.java
@@ -302,6 +302,9 @@ public class TransactionServiceImplementation implements TransactionService {
   public TransactionDto confirm(Long id) {
     Transaction transaction = this.transactionRepository.findActiveById(id)
         .orElseThrow(() -> new ResourceNotFoundException("Transaction", "id", id.toString()));
+    if (!transaction.getPending()) {
+      throw new IllegalArgumentException("TRANSACTION_NOT_PENDING");
+    }
     transaction.setExcludeFromTotals(false);
     transaction.setPending(false);
     return mapper.map(this.transactionRepository.save(transaction), TransactionDto.class);

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementation.java
@@ -166,6 +166,8 @@ public class TransactionServiceImplementation implements TransactionService {
       transaction.setDescription("TRANSFER.OUT.DESCRIPTION");
     }
     transaction.setAmount(amount);
+    transaction.setPending(transaction.getType() != TransactionTypeEnum.TRANSFER && transaction.getExcludeFromTotals()
+        && transaction.getEventDate().isAfter(OffsetDateTime.now()));
     transaction.setOwner(user);
     transaction.setAccount(transactionAccount);
     transaction.setCategory(transactionCategory);
@@ -194,7 +196,8 @@ public class TransactionServiceImplementation implements TransactionService {
         .and(TransactionSpecifications.hasSubcategoryIds(subcategoryIds))
         .and(TransactionSpecifications.hasAccountIds(accountIds))
         .and(TransactionSpecifications.hasMinAmount(minAmount)).and(TransactionSpecifications.hasMaxAmount(maxAmount))
-        .and(TransactionSpecifications.occurredAfter(fromDate)).and(TransactionSpecifications.occurredBefore(toDate)),
+        .and(TransactionSpecifications.occurredAfter(fromDate)).and(TransactionSpecifications.occurredBefore(toDate))
+        .and(TransactionSpecifications.isNotPending()),
         pageable).map(transaction -> mapper.map(transaction, TransactionDto.class));
   }
 
@@ -210,7 +213,7 @@ public class TransactionServiceImplementation implements TransactionService {
         .and(TransactionSpecifications.hasAccountIds(accountIds))
         .and(TransactionSpecifications.hasMinAmount(minAmount)).and(TransactionSpecifications.hasMaxAmount(maxAmount))
         .and(TransactionSpecifications.occurredAfter(fromDate)).and(TransactionSpecifications.occurredBefore(toDate))
-        .and(TransactionSpecifications.notExcludedFromTotals()));
+        .and(TransactionSpecifications.notExcludedFromTotals()).and(TransactionSpecifications.isNotPending()));
 
     Map<CurrencyEnum, BalanceSummaryDto> totalsByCurrency = new HashMap<>();
     for (Transaction transaction : transactions) {
@@ -282,6 +285,9 @@ public class TransactionServiceImplementation implements TransactionService {
     }
 
 
+    transaction.setPending(transaction.getType() != TransactionTypeEnum.TRANSFER && transaction.getExcludeFromTotals()
+        && transaction.getEventDate().isAfter(OffsetDateTime.now()));
+
     Transaction updatedTransaction = this.transactionRepository.save(transaction);
 
     if (idToDelete != null) {
@@ -289,6 +295,24 @@ public class TransactionServiceImplementation implements TransactionService {
     }
 
     return mapper.map(updatedTransaction, TransactionDto.class);
+  }
+
+  @Transactional
+  @Override
+  public TransactionDto confirm(Long id) {
+    Transaction transaction = this.transactionRepository.findActiveById(id)
+        .orElseThrow(() -> new ResourceNotFoundException("Transaction", "id", id.toString()));
+    transaction.setExcludeFromTotals(false);
+    transaction.setPending(false);
+    return mapper.map(this.transactionRepository.save(transaction), TransactionDto.class);
+  }
+
+  @Override
+  public List<TransactionDto> getPendingTransactions() {
+    Specification<Transaction> spec = Specification.where(BaseEntitySpecifications.<Transaction>activeForCurrentUser())
+        .and(TransactionSpecifications.isPending());
+    return transactionRepository.findAll(spec).stream()
+        .map(transaction -> mapper.map(transaction, TransactionDto.class)).collect(Collectors.toList());
   }
 
   @Transactional
@@ -344,7 +368,8 @@ public class TransactionServiceImplementation implements TransactionService {
     User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
     OffsetDateTime startDate = OffsetDateTime.of(year, month, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     OffsetDateTime endDate = startDate.plusMonths(1).minusSeconds(1);
-    return this.transactionRepository.findByOwnerAndEventDateBetweenAndDeletedFalse(user, startDate, endDate).stream()
+    return this.transactionRepository
+        .findByOwnerAndEventDateBetweenAndPendingFalseAndDeletedFalse(user, startDate, endDate).stream()
         .map(transaction -> mapper.map(transaction, TransactionDto.class)).collect(Collectors.toList());
   }
 }

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
@@ -1,8 +1,10 @@
 package com.manuelfabri.expenses.service.implementation;
 
 import java.math.BigDecimal;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -186,12 +188,18 @@ public class TransactionStatisticsServiceImplementation implements TransactionSt
   public List<MonthlyBalanceSummaryDto> getMonthlyHistory(int months, boolean includePending) {
     OffsetDateTime fromDate = OffsetDateTime.now().minusMonths(months - 1).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
 
-    List<Object[]> incomeResults = includePending
-        ? this.transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)
-        : this.transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
-    List<Object[]> expenseResults = includePending
-        ? this.transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)
-        : this.transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
+    List<Object[]> incomeResults;
+    List<Object[]> expenseResults;
+    if (includePending) {
+      OffsetDateTime toDate =
+          OffsetDateTime.now().with(TemporalAdjusters.lastDayOfMonth()).with(LocalTime.MAX);
+      incomeResults = this.transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate);
+      expenseResults =
+          this.transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate);
+    } else {
+      incomeResults = this.transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
+      expenseResults = this.transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
+    }
 
     return buildMonthlyBalances(incomeResults, expenseResults);
   }

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
@@ -179,10 +179,25 @@ public class TransactionStatisticsServiceImplementation implements TransactionSt
 
   @Override
   public List<MonthlyBalanceSummaryDto> getMonthlyHistory(int months) {
-    OffsetDateTime fromDate = OffsetDateTime.now().minusMonths(months - 1).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
-    List<Object[]> incomeResults = this.transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
-    List<Object[]> expenseResults = this.transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
+    return getMonthlyHistory(months, false);
+  }
 
+  @Override
+  public List<MonthlyBalanceSummaryDto> getMonthlyHistory(int months, boolean includePending) {
+    OffsetDateTime fromDate = OffsetDateTime.now().minusMonths(months - 1).withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS);
+
+    List<Object[]> incomeResults = includePending
+        ? this.transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)
+        : this.transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
+    List<Object[]> expenseResults = includePending
+        ? this.transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)
+        : this.transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
+
+    return buildMonthlyBalances(incomeResults, expenseResults);
+  }
+
+  private List<MonthlyBalanceSummaryDto> buildMonthlyBalances(List<Object[]> incomeResults,
+      List<Object[]> expenseResults) {
     Map<String, MonthlyBalanceSummaryDto> monthlyBalancesByKey = new HashMap<>();
 
     incomeResults.forEach(row -> {

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementation.java
@@ -12,16 +12,21 @@ import org.springframework.stereotype.Service;
 import com.manuelfabri.expenses.dto.CategoryTotalsDto;
 import com.manuelfabri.expenses.dto.MonthlyBalanceSummaryDto;
 import com.manuelfabri.expenses.dto.SubTotalsPerSubcategoryDto;
+import com.manuelfabri.expenses.model.Account;
 import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.repository.AccountRepository;
 import com.manuelfabri.expenses.repository.TransactionRepository;
 import com.manuelfabri.expenses.service.TransactionStatisticsService;
 
 @Service
 public class TransactionStatisticsServiceImplementation implements TransactionStatisticsService {
   private TransactionRepository transactionRepository;
+  private AccountRepository accountRepository;
 
-  public TransactionStatisticsServiceImplementation(TransactionRepository transactionRepository) {
+  public TransactionStatisticsServiceImplementation(TransactionRepository transactionRepository,
+      AccountRepository accountRepository) {
     this.transactionRepository = transactionRepository;
+    this.accountRepository = accountRepository;
   }
 
   private Map<CurrencyEnum, BigDecimal> parseTotalsByCurrency(List<Object[]> results) {
@@ -133,8 +138,8 @@ public class TransactionStatisticsServiceImplementation implements TransactionSt
 
   @Override
   public Map<CurrencyEnum, BigDecimal> getBalancesByCurrency() {
-    List<Object[]> results = this.transactionRepository.getBalancesByCurrency();
-    return parseTotalsByCurrency(results);
+    return this.accountRepository.findActive().stream().collect(Collectors.groupingBy(Account::getCurrency,
+        Collectors.reducing(BigDecimal.ZERO, Account::getAccountBalance, BigDecimal::add)));
   }
 
   @Override

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
@@ -11,6 +11,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.modelmapper.ModelMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
@@ -45,11 +46,11 @@ public class UpcomingTransactionServiceImplementation implements UpcomingTransac
     this.mapper = mapper;
   }
 
-  private UpcomingTransactionItemDto fromRecurrence(RecurrentTransaction recurrence, LocalDate dueDate) {
+  private UpcomingTransactionItemDto fromRecurrence(RecurrentTransaction recurrence, Optional<LocalDate> dueDate) {
     UpcomingTransactionItemDto dto = new UpcomingTransactionItemDto();
     dto.setSourceType(SourceTypeEnum.RECURRING);
     dto.setSourceId(recurrence.getId());
-    dto.setDate(dueDate.atStartOfDay().atOffset(recurrence.getStartDate().getOffset()));
+    dto.setDate(dueDate.map(date -> date.atStartOfDay().atOffset(recurrence.getStartDate().getOffset())).orElse(null));
     dto.setDescription(recurrence.getDescription());
     dto.setCategoryIconName(recurrence.getCategory().getIconName());
     dto.setCategoryColor(recurrence.getCategory().getColor());
@@ -140,7 +141,7 @@ public class UpcomingTransactionServiceImplementation implements UpcomingTransac
       }
       dateCalculator.nextDueDate(recurrence)
           .filter(dueDate -> !dueDate.isBefore(today) && !dueDate.isAfter(endOfMonth)).ifPresent(dueDate -> {
-            UpcomingTransactionItemDto dto = fromRecurrence(recurrence, dueDate);
+            UpcomingTransactionItemDto dto = fromRecurrence(recurrence, Optional.of(dueDate));
             CurrencyEnum currency = recurrence.getAccount().getCurrency();
             bucketByCurrency(recurrence.getType(), currency, dto, expensesByCurrency, incomesByCurrency);
           });
@@ -172,16 +173,16 @@ public class UpcomingTransactionServiceImplementation implements UpcomingTransac
       if (!isActiveOrPaused) {
         continue;
       }
-      dateCalculator.nextDueDate(recurrence)
-          .ifPresent(dueDate -> bucket(recurrence.getType(), fromRecurrence(recurrence, dueDate), expenses, incomes));
+      Optional<LocalDate> dueDate = dateCalculator.nextDueDate(recurrence);
+      bucket(recurrence.getType(), fromRecurrence(recurrence, dueDate), expenses, incomes);
     }
 
     for (Transaction transaction : transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(user)) {
       bucket(transaction.getType(), fromTransaction(transaction), expenses, incomes);
     }
 
-    expenses.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
-    incomes.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
+    expenses.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate, Comparator.nullsLast(Comparator.naturalOrder())));
+    incomes.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate, Comparator.nullsLast(Comparator.naturalOrder())));
 
     ProgrammedTransactionsDto response = new ProgrammedTransactionsDto();
     response.setExpenses(expenses);

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.modelmapper.ModelMapper;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
@@ -36,14 +35,12 @@ public class UpcomingTransactionServiceImplementation implements UpcomingTransac
   private RecurrentTransactionRepository recurrentTransactionRepository;
   private TransactionRepository transactionRepository;
   private RecurrenceDateCalculator dateCalculator;
-  private ModelMapper mapper;
 
   public UpcomingTransactionServiceImplementation(RecurrentTransactionRepository recurrentTransactionRepository,
-      TransactionRepository transactionRepository, RecurrenceDateCalculator dateCalculator, ModelMapper mapper) {
+      TransactionRepository transactionRepository, RecurrenceDateCalculator dateCalculator) {
     this.recurrentTransactionRepository = recurrentTransactionRepository;
     this.transactionRepository = transactionRepository;
     this.dateCalculator = dateCalculator;
-    this.mapper = mapper;
   }
 
   private UpcomingTransactionItemDto fromRecurrence(RecurrentTransaction recurrence, Optional<LocalDate> dueDate) {
@@ -108,7 +105,7 @@ public class UpcomingTransactionServiceImplementation implements UpcomingTransac
     List<UpcomingTransactionGroupDto> groups = new ArrayList<>();
     for (Map.Entry<CurrencyEnum, List<UpcomingTransactionItemDto>> entry : byCurrency.entrySet()) {
       List<UpcomingTransactionItemDto> items = new ArrayList<>(entry.getValue());
-      items.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
+      items.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate, Comparator.nullsLast(Comparator.naturalOrder())));
 
       BigDecimal total = items.stream().map(UpcomingTransactionItemDto::getSignedAmount).reduce(BigDecimal.ZERO,
           BigDecimal::add);

--- a/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
+++ b/src/main/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementation.java
@@ -1,0 +1,191 @@
+package com.manuelfabri.expenses.service.implementation;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionGroupDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionItemDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionsResponseDto;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.RecurrenceStatusEnum;
+import com.manuelfabri.expenses.model.RecurrentTransaction;
+import com.manuelfabri.expenses.model.SourceTypeEnum;
+import com.manuelfabri.expenses.model.Transaction;
+import com.manuelfabri.expenses.model.TransactionTypeEnum;
+import com.manuelfabri.expenses.model.User;
+import com.manuelfabri.expenses.repository.RecurrentTransactionRepository;
+import com.manuelfabri.expenses.repository.TransactionRepository;
+import com.manuelfabri.expenses.service.RecurrenceDateCalculator;
+import com.manuelfabri.expenses.service.UpcomingTransactionService;
+
+@Service
+public class UpcomingTransactionServiceImplementation implements UpcomingTransactionService {
+  private RecurrentTransactionRepository recurrentTransactionRepository;
+  private TransactionRepository transactionRepository;
+  private RecurrenceDateCalculator dateCalculator;
+  private ModelMapper mapper;
+
+  public UpcomingTransactionServiceImplementation(RecurrentTransactionRepository recurrentTransactionRepository,
+      TransactionRepository transactionRepository, RecurrenceDateCalculator dateCalculator, ModelMapper mapper) {
+    this.recurrentTransactionRepository = recurrentTransactionRepository;
+    this.transactionRepository = transactionRepository;
+    this.dateCalculator = dateCalculator;
+    this.mapper = mapper;
+  }
+
+  private UpcomingTransactionItemDto fromRecurrence(RecurrentTransaction recurrence, LocalDate dueDate) {
+    UpcomingTransactionItemDto dto = new UpcomingTransactionItemDto();
+    dto.setSourceType(SourceTypeEnum.RECURRING);
+    dto.setSourceId(recurrence.getId());
+    dto.setDate(dueDate.atStartOfDay().atOffset(recurrence.getStartDate().getOffset()));
+    dto.setDescription(recurrence.getDescription());
+    dto.setCategoryIconName(recurrence.getCategory().getIconName());
+    dto.setCategoryColor(recurrence.getCategory().getColor());
+    dto.setAccountId(recurrence.getAccount().getId());
+    dto.setSignedAmount(recurrence.getType().applySign(recurrence.getAmount()));
+    dto.setFrequency(recurrence.getFrequency());
+    dto.setIntervalDays(recurrence.getIntervalDays());
+    dto.setDaysOfMonth(recurrence.getDaysOfMonth());
+    return dto;
+  }
+
+  private UpcomingTransactionItemDto fromTransaction(Transaction transaction) {
+    UpcomingTransactionItemDto dto = new UpcomingTransactionItemDto();
+    dto.setSourceType(SourceTypeEnum.ONE_TIME);
+    dto.setSourceId(transaction.getId());
+    dto.setDate(transaction.getEventDate());
+    dto.setDescription(transaction.getDescription());
+    dto.setCategoryIconName(transaction.getCategory().getIconName());
+    dto.setCategoryColor(transaction.getCategory().getColor());
+    dto.setAccountId(transaction.getAccount().getId());
+    dto.setSignedAmount(transaction.getAmount());
+    return dto; // frequency/intervalDays/daysOfMonth left null
+  }
+
+  /**
+   * Routes an item into the expense or income bucket for its type. Transfers (which shouldn't reach this service in
+   * practice — recurrences can't be TRANSFER, and one-time transfers are never pending) are intentionally dropped
+   * rather than crashing, so a mixed input never leaks a transfer into either bucket.
+   */
+  private void bucket(TransactionTypeEnum type, UpcomingTransactionItemDto dto,
+      List<UpcomingTransactionItemDto> expenses, List<UpcomingTransactionItemDto> incomes) {
+    if (type == TransactionTypeEnum.EXPENSE) {
+      expenses.add(dto);
+    } else if (type == TransactionTypeEnum.INCOME) {
+      incomes.add(dto);
+    }
+  }
+
+  /**
+   * Same routing as {@link #bucket}, but only materializes a currency's list in the map the item actually belongs
+   * to — computing both maps unconditionally would leave a spurious empty group in the other bucket.
+   */
+  private void bucketByCurrency(TransactionTypeEnum type, CurrencyEnum currency, UpcomingTransactionItemDto dto,
+      Map<CurrencyEnum, List<UpcomingTransactionItemDto>> expensesByCurrency,
+      Map<CurrencyEnum, List<UpcomingTransactionItemDto>> incomesByCurrency) {
+    if (type == TransactionTypeEnum.EXPENSE) {
+      expensesByCurrency.computeIfAbsent(currency, c -> new ArrayList<>()).add(dto);
+    } else if (type == TransactionTypeEnum.INCOME) {
+      incomesByCurrency.computeIfAbsent(currency, c -> new ArrayList<>()).add(dto);
+    }
+  }
+
+  private List<UpcomingTransactionGroupDto> groupByCurrency(
+      Map<CurrencyEnum, List<UpcomingTransactionItemDto>> byCurrency) {
+    List<UpcomingTransactionGroupDto> groups = new ArrayList<>();
+    for (Map.Entry<CurrencyEnum, List<UpcomingTransactionItemDto>> entry : byCurrency.entrySet()) {
+      List<UpcomingTransactionItemDto> items = new ArrayList<>(entry.getValue());
+      items.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
+
+      BigDecimal total = items.stream().map(UpcomingTransactionItemDto::getSignedAmount).reduce(BigDecimal.ZERO,
+          BigDecimal::add);
+
+      UpcomingTransactionGroupDto group = new UpcomingTransactionGroupDto();
+      group.setCurrency(entry.getKey().name());
+      group.setTotal(total);
+      group.setItems(items);
+      groups.add(group);
+    }
+    groups.sort(Comparator.comparing(UpcomingTransactionGroupDto::getCurrency));
+    return groups;
+  }
+
+  @Override
+  public UpcomingTransactionsResponseDto getUpcomingTransactions() {
+    User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    LocalDate today = OffsetDateTime.now(ZoneOffset.UTC).toLocalDate();
+    LocalDate endOfMonth = YearMonth.from(today).atEndOfMonth();
+    OffsetDateTime windowStart = OffsetDateTime.of(today, LocalTime.MIN, ZoneOffset.UTC);
+    OffsetDateTime windowEnd = OffsetDateTime.of(endOfMonth, LocalTime.MAX, ZoneOffset.UTC);
+
+    Map<CurrencyEnum, List<UpcomingTransactionItemDto>> expensesByCurrency = new LinkedHashMap<>();
+    Map<CurrencyEnum, List<UpcomingTransactionItemDto>> incomesByCurrency = new LinkedHashMap<>();
+
+    for (RecurrentTransaction recurrence : recurrentTransactionRepository.findActiveVisible()) {
+      if (recurrence.getStatus() != RecurrenceStatusEnum.ACTIVE) {
+        continue;
+      }
+      dateCalculator.nextDueDate(recurrence)
+          .filter(dueDate -> !dueDate.isBefore(today) && !dueDate.isAfter(endOfMonth)).ifPresent(dueDate -> {
+            UpcomingTransactionItemDto dto = fromRecurrence(recurrence, dueDate);
+            CurrencyEnum currency = recurrence.getAccount().getCurrency();
+            bucketByCurrency(recurrence.getType(), currency, dto, expensesByCurrency, incomesByCurrency);
+          });
+    }
+
+    for (Transaction transaction : transactionRepository
+        .findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(user, windowStart, windowEnd)) {
+      UpcomingTransactionItemDto dto = fromTransaction(transaction);
+      CurrencyEnum currency = transaction.getAccount().getCurrency();
+      bucketByCurrency(transaction.getType(), currency, dto, expensesByCurrency, incomesByCurrency);
+    }
+
+    UpcomingTransactionsResponseDto response = new UpcomingTransactionsResponseDto();
+    response.setExpenses(groupByCurrency(expensesByCurrency));
+    response.setIncomes(groupByCurrency(incomesByCurrency));
+    return response;
+  }
+
+  @Override
+  public ProgrammedTransactionsDto getProgrammedTransactions() {
+    User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    List<UpcomingTransactionItemDto> expenses = new ArrayList<>();
+    List<UpcomingTransactionItemDto> incomes = new ArrayList<>();
+
+    for (RecurrentTransaction recurrence : recurrentTransactionRepository.findActiveVisible()) {
+      RecurrenceStatusEnum status = recurrence.getStatus();
+      boolean isActiveOrPaused = status == RecurrenceStatusEnum.ACTIVE || status == RecurrenceStatusEnum.PAUSED;
+      if (!isActiveOrPaused) {
+        continue;
+      }
+      dateCalculator.nextDueDate(recurrence)
+          .ifPresent(dueDate -> bucket(recurrence.getType(), fromRecurrence(recurrence, dueDate), expenses, incomes));
+    }
+
+    for (Transaction transaction : transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(user)) {
+      bucket(transaction.getType(), fromTransaction(transaction), expenses, incomes);
+    }
+
+    expenses.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
+    incomes.sort(Comparator.comparing(UpcomingTransactionItemDto::getDate));
+
+    ProgrammedTransactionsDto response = new ProgrammedTransactionsDto();
+    response.setExpenses(expenses);
+    response.setIncomes(incomes);
+    return response;
+  }
+}

--- a/src/main/java/com/manuelfabri/specification/TransactionSpecifications.java
+++ b/src/main/java/com/manuelfabri/specification/TransactionSpecifications.java
@@ -48,4 +48,12 @@ public class TransactionSpecifications {
   public static Specification<Transaction> notExcludedFromTotals() {
     return (root, query, cb) -> cb.isFalse(root.get("excludeFromTotals"));
   }
+
+  public static Specification<Transaction> isNotPending() {
+    return (root, query, cb) -> cb.isFalse(root.get("pending"));
+  }
+
+  public static Specification<Transaction> isPending() {
+    return (root, query, cb) -> cb.isTrue(root.get("pending"));
+  }
 }

--- a/src/main/resources/db/changelog/10-add-pending-to-transactions.yaml
+++ b/src/main/resources/db/changelog/10-add-pending-to-transactions.yaml
@@ -1,0 +1,14 @@
+databaseChangeLog:
+  - changeSet:
+      id: 10-add-pending-to-transactions
+      author: manufabri91
+      changes:
+        - addColumn:
+            tableName: transactions
+            columns:
+              - column:
+                  name: pending
+                  type: boolean
+                  defaultValueBoolean: false
+                  constraints:
+                    nullable: false

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -19,3 +19,5 @@ databaseChangeLog:
       file: db/changelog/8-add-recurrent-transactions.yaml
   - include:
       file: db/changelog/9-add-user-settings.yaml
+  - include:
+      file: db/changelog/10-add-pending-to-transactions.yaml

--- a/src/test/java/com/manuelfabri/expenses/controller/SummaryControllerTest.java
+++ b/src/test/java/com/manuelfabri/expenses/controller/SummaryControllerTest.java
@@ -1,5 +1,6 @@
 package com.manuelfabri.expenses.controller;
 
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import com.manuelfabri.expenses.dto.BalanceSummaryDto;
+import com.manuelfabri.expenses.dto.MonthlyBalanceSummaryDto;
 import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
 import com.manuelfabri.expenses.dto.UpcomingTransactionGroupDto;
 import com.manuelfabri.expenses.dto.UpcomingTransactionItemDto;
@@ -87,5 +89,27 @@ class SummaryControllerTest {
         .andExpect(jsonPath("$.expenses[0].sourceId").value(5))
         .andExpect(jsonPath("$.expenses[0].sourceType").value("ONE_TIME"))
         .andExpect(jsonPath("$.incomes.length()").value(0));
+  }
+
+  @Test
+  void getMonthlyHistory_withIncludePendingTrue_passesTheFlagThroughToTheService() throws Exception {
+    MonthlyBalanceSummaryDto dto = new MonthlyBalanceSummaryDto();
+    when(transactionStatisticsService.getMonthlyHistory(6, true)).thenReturn(List.of(dto));
+
+    mockMvc.perform(get("/summary/monthly-history/6").param("includePending", "true")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1));
+
+    verify(transactionStatisticsService).getMonthlyHistory(6, true);
+  }
+
+  @Test
+  void getMonthlyHistory_withoutIncludePendingParam_defaultsToFalse() throws Exception {
+    MonthlyBalanceSummaryDto dto = new MonthlyBalanceSummaryDto();
+    when(transactionStatisticsService.getMonthlyHistory(6, false)).thenReturn(List.of(dto));
+
+    mockMvc.perform(get("/summary/monthly-history/6")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1));
+
+    verify(transactionStatisticsService).getMonthlyHistory(6, false);
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/controller/SummaryControllerTest.java
+++ b/src/test/java/com/manuelfabri/expenses/controller/SummaryControllerTest.java
@@ -1,0 +1,91 @@
+package com.manuelfabri.expenses.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.manuelfabri.expenses.dto.BalanceSummaryDto;
+import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionGroupDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionItemDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionsResponseDto;
+import com.manuelfabri.expenses.model.SourceTypeEnum;
+import com.manuelfabri.expenses.service.SummaryService;
+import com.manuelfabri.expenses.service.TransactionStatisticsService;
+import com.manuelfabri.expenses.service.UpcomingTransactionService;
+
+@WebMvcTest(controllers = SummaryController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class SummaryControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private SummaryService summaryService;
+  @MockBean
+  private TransactionStatisticsService transactionStatisticsService;
+  @MockBean
+  private UpcomingTransactionService upcomingTransactionService;
+
+  @Test
+  void getDefaultSummary_returnsOkWithTheServiceList() throws Exception {
+    BalanceSummaryDto dto = new BalanceSummaryDto();
+    when(summaryService.getMonthlySummaryWithTotalBalance(2024, 1)).thenReturn(List.of(dto));
+
+    mockMvc.perform(get("/summary").param("year", "2024").param("month", "1")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1));
+  }
+
+  @Test
+  void getUpcomingTransactions_returnsOkWithTheServiceResponse() throws Exception {
+    UpcomingTransactionItemDto item = new UpcomingTransactionItemDto();
+    item.setSourceType(SourceTypeEnum.RECURRING);
+    item.setSourceId(1L);
+    item.setSignedAmount(new BigDecimal("-30.00"));
+
+    UpcomingTransactionGroupDto group = new UpcomingTransactionGroupDto();
+    group.setCurrency("USD");
+    group.setTotal(new BigDecimal("-30.00"));
+    group.setItems(List.of(item));
+
+    UpcomingTransactionsResponseDto response = new UpcomingTransactionsResponseDto();
+    response.setExpenses(List.of(group));
+    response.setIncomes(List.of());
+    when(upcomingTransactionService.getUpcomingTransactions()).thenReturn(response);
+
+    mockMvc.perform(get("/summary/upcoming-transactions")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.expenses.length()").value(1))
+        .andExpect(jsonPath("$.expenses[0].currency").value("USD"))
+        .andExpect(jsonPath("$.expenses[0].total").value(-30.00))
+        .andExpect(jsonPath("$.expenses[0].items[0].sourceId").value(1))
+        .andExpect(jsonPath("$.incomes.length()").value(0));
+  }
+
+  @Test
+  void getProgrammedTransactions_returnsOkWithTheServiceResponse() throws Exception {
+    UpcomingTransactionItemDto expenseItem = new UpcomingTransactionItemDto();
+    expenseItem.setSourceType(SourceTypeEnum.ONE_TIME);
+    expenseItem.setSourceId(5L);
+    expenseItem.setSignedAmount(new BigDecimal("-12.50"));
+
+    ProgrammedTransactionsDto response = new ProgrammedTransactionsDto();
+    response.setExpenses(List.of(expenseItem));
+    response.setIncomes(List.of());
+    when(upcomingTransactionService.getProgrammedTransactions()).thenReturn(response);
+
+    mockMvc.perform(get("/summary/programmed-transactions")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.expenses.length()").value(1))
+        .andExpect(jsonPath("$.expenses[0].sourceId").value(5))
+        .andExpect(jsonPath("$.expenses[0].sourceType").value("ONE_TIME"))
+        .andExpect(jsonPath("$.incomes.length()").value(0));
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/controller/TransactionControllerTest.java
+++ b/src/test/java/com/manuelfabri/expenses/controller/TransactionControllerTest.java
@@ -1,0 +1,107 @@
+package com.manuelfabri.expenses.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import com.manuelfabri.expenses.dto.CategoryDto;
+import com.manuelfabri.expenses.dto.SubcategoryDto;
+import com.manuelfabri.expenses.dto.TransactionDto;
+import com.manuelfabri.expenses.exception.ResourceNotFoundException;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.TransactionTypeEnum;
+import com.manuelfabri.expenses.service.TransactionService;
+
+@WebMvcTest(controllers = TransactionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+class TransactionControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private TransactionService transactionService;
+
+  private TransactionDto sampleDto(Long id) {
+    TransactionDto dto = new TransactionDto();
+    dto.setId(id);
+    dto.setEventDate(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    dto.setDescription("Weekly groceries");
+    dto.setAmount(new BigDecimal("-45.50"));
+    dto.setType(TransactionTypeEnum.EXPENSE);
+    dto.setCurrencyCode(CurrencyEnum.USD);
+    dto.setAccountId(10L);
+    dto.setAccountName("Checking");
+
+    CategoryDto category = new CategoryDto();
+    category.setId(20L);
+    category.setName("Groceries");
+    dto.setCategory(category);
+
+    SubcategoryDto subcategory = new SubcategoryDto();
+    subcategory.setId(30L);
+    subcategory.setName("Supermarket");
+    dto.setSubcategory(subcategory);
+
+    return dto;
+  }
+
+  @Test
+  void confirm_delegatesToTheServiceAndReturnsOkWithTheMappedBody() throws Exception {
+    TransactionDto confirmedDto = sampleDto(1L);
+    confirmedDto.setExcludeFromTotals(false);
+    confirmedDto.setPending(false);
+    when(transactionService.confirm(1L)).thenReturn(confirmedDto);
+
+    mockMvc.perform(patch("/transaction/{id}/confirm", 1L)).andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1)).andExpect(jsonPath("$.pending").value(false))
+        .andExpect(jsonPath("$.excludeFromTotals").value(false));
+    verify(transactionService).confirm(1L);
+  }
+
+  @Test
+  void confirm_returnsNotFound_whenServiceThrowsResourceNotFound() throws Exception {
+    when(transactionService.confirm(404L)).thenThrow(new ResourceNotFoundException("Transaction", "id", "404"));
+
+    mockMvc.perform(patch("/transaction/{id}/confirm", 404L)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void getPendingTransactions_returnsOkWithTheServiceList() throws Exception {
+    TransactionDto pendingDto = sampleDto(1L);
+    pendingDto.setPending(true);
+    pendingDto.setExcludeFromTotals(true);
+    when(transactionService.getPendingTransactions()).thenReturn(List.of(pendingDto));
+
+    mockMvc.perform(get("/transaction/pending")).andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1)).andExpect(jsonPath("$[0].id").value(1))
+        .andExpect(jsonPath("$[0].pending").value(true));
+  }
+
+  @Test
+  void getPendingTransactions_isNotSwallowedByTheIdOrYearMonthRoutes() throws Exception {
+    // The controller also exposes GET /transaction/{id} (Long) and GET /transaction/{year}/{month} (int, int).
+    // "pending" is a single path segment, same shape as {id}, so this proves Spring routes the literal
+    // "/pending" segment to getPendingTransactions() rather than attempting (and failing) to parse it as a Long id.
+    when(transactionService.getPendingTransactions()).thenReturn(List.of());
+
+    mockMvc.perform(get("/transaction/pending")).andExpect(status().isOk()).andExpect(jsonPath("$").isArray());
+
+    verify(transactionService).getPendingTransactions();
+    verify(transactionService, never()).getById(any());
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/repository/AccountRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/AccountRepositoryTest.java
@@ -71,6 +71,11 @@ class AccountRepositoryTest {
   }
 
   private Transaction persistTransaction(Account forAccount, BigDecimal amount, boolean excludeFromTotals) {
+    return persistTransaction(forAccount, amount, excludeFromTotals, false);
+  }
+
+  private Transaction persistTransaction(Account forAccount, BigDecimal amount, boolean excludeFromTotals,
+      boolean pending) {
     Transaction transaction = new Transaction();
     transaction.setOwner(owner);
     transaction.setType(TransactionTypeEnum.EXPENSE);
@@ -81,6 +86,7 @@ class AccountRepositoryTest {
     transaction.setCategory(category);
     transaction.setSubcategory(subcategory);
     transaction.setExcludeFromTotals(excludeFromTotals);
+    transaction.setPending(pending);
     return entityManager.persistAndFlush(transaction);
   }
 
@@ -116,10 +122,25 @@ class AccountRepositoryTest {
   }
 
   @Test
-  void accountBalance_excludesAnExcludeFromTotalsTransaction() {
+  void accountBalance_includesATransferLegShapedExcludeFromTotalsTransaction() {
+    // Transfer legs are written with excludeFromTotals = true but pending = false: the money genuinely moved,
+    // so it must still count toward the account's balance.
     account = persistAccount(new BigDecimal("100.00"));
     persistTransaction(account, new BigDecimal("-20.00"), false);
-    persistTransaction(account, new BigDecimal("-50.00"), true);
+    persistTransaction(account, new BigDecimal("-50.00"), true, false);
+
+    Account reloaded = reloadAccount();
+
+    assertThat(reloaded.getAccountBalance()).isEqualByComparingTo("30.00");
+  }
+
+  @Test
+  void accountBalance_excludesAPendingTransaction() {
+    // Pending transactions haven't happened yet (money hasn't moved), so they must not count until their date
+    // arrives and activateDuePendingTransactions clears the pending flag.
+    account = persistAccount(new BigDecimal("100.00"));
+    persistTransaction(account, new BigDecimal("-20.00"), false);
+    persistTransaction(account, new BigDecimal("-50.00"), true, true);
 
     Account reloaded = reloadAccount();
 

--- a/src/test/java/com/manuelfabri/expenses/repository/AccountRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/AccountRepositoryTest.java
@@ -1,0 +1,137 @@
+package com.manuelfabri.expenses.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.manuelfabri.expenses.model.Account;
+import com.manuelfabri.expenses.model.Category;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.Subcategory;
+import com.manuelfabri.expenses.model.Transaction;
+import com.manuelfabri.expenses.model.TransactionTypeEnum;
+import com.manuelfabri.expenses.model.User;
+
+/**
+ * Covers {@link Account#getAccountBalance()}, the Hibernate {@code @Formula}-computed running balance. The formula
+ * is raw native SQL against the real column names, so every assertion here reloads the account from a cleared
+ * persistence context ({@link #reloadAccount()}) to force Hibernate to re-evaluate the formula rather than reuse the
+ * managed instance created by {@code persist}.
+ */
+@DataJpaTest
+class AccountRepositoryTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+  @Autowired
+  private AccountRepository accountRepository;
+  @Autowired
+  private TransactionRepository transactionRepository;
+
+  private User owner;
+  private Account account;
+  private Category category;
+  private Subcategory subcategory;
+
+  @BeforeEach
+  void setUp() {
+    owner = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
+    entityManager.persist(owner);
+    category = new Category(null, "Groceries", "icon", "#fff", owner, List.of());
+    category.setType(TransactionTypeEnum.EXPENSE);
+    entityManager.persist(category);
+    subcategory = new Subcategory(null, "Supermarket", category, List.of(), owner);
+    entityManager.persist(subcategory);
+
+    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(owner, null));
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private Account persistAccount(BigDecimal initialBalance) {
+    Account newAccount = new Account(null, "Checking", CurrencyEnum.USD, owner);
+    newAccount.setInitialBalance(initialBalance);
+    return entityManager.persistAndFlush(newAccount);
+  }
+
+  private Transaction persistTransaction(Account forAccount, BigDecimal amount, boolean excludeFromTotals) {
+    Transaction transaction = new Transaction();
+    transaction.setOwner(owner);
+    transaction.setType(TransactionTypeEnum.EXPENSE);
+    transaction.setAmount(amount);
+    transaction.setDescription("Test transaction");
+    transaction.setEventDate(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    transaction.setAccount(forAccount);
+    transaction.setCategory(category);
+    transaction.setSubcategory(subcategory);
+    transaction.setExcludeFromTotals(excludeFromTotals);
+    return entityManager.persistAndFlush(transaction);
+  }
+
+  private Account reloadAccount() {
+    entityManager.clear();
+    return accountRepository.findActiveById(account.getId()).orElseThrow();
+  }
+
+  // --- accountBalance formula ------------------------------------------------------------------------------------
+
+  @Test
+  void accountBalance_includesInitialBalancePlusNormalTransactions() {
+    account = persistAccount(new BigDecimal("100.00"));
+    persistTransaction(account, new BigDecimal("50.00"), false);
+    persistTransaction(account, new BigDecimal("-20.00"), false);
+
+    Account reloaded = reloadAccount();
+
+    assertThat(reloaded.getAccountBalance()).isEqualByComparingTo("130.00");
+  }
+
+  @Test
+  void accountBalance_excludesASoftDeletedTransaction() {
+    account = persistAccount(new BigDecimal("100.00"));
+    persistTransaction(account, new BigDecimal("-20.00"), false);
+    Transaction softDeleted = persistTransaction(account, new BigDecimal("-1000.00"), false);
+    transactionRepository.softDeleteById(softDeleted.getId());
+    entityManager.flush();
+
+    Account reloaded = reloadAccount();
+
+    assertThat(reloaded.getAccountBalance()).isEqualByComparingTo("80.00");
+  }
+
+  @Test
+  void accountBalance_excludesAnExcludeFromTotalsTransaction() {
+    account = persistAccount(new BigDecimal("100.00"));
+    persistTransaction(account, new BigDecimal("-20.00"), false);
+    persistTransaction(account, new BigDecimal("-50.00"), true);
+
+    Account reloaded = reloadAccount();
+
+    assertThat(reloaded.getAccountBalance()).isEqualByComparingTo("80.00");
+  }
+
+  @Test
+  void accountBalance_withNoTransactions_equalsInitialBalance() {
+    account = persistAccount(new BigDecimal("250.00"));
+
+    Account reloaded = reloadAccount();
+
+    assertThat(reloaded.getAccountBalance()).isEqualByComparingTo("250.00");
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
@@ -69,10 +69,15 @@ class TransactionRepositoryTest {
   }
 
   private Transaction persistTransaction(OffsetDateTime eventDate, boolean pending, boolean excludeFromTotals) {
+    return persistTransaction(eventDate, pending, excludeFromTotals, new BigDecimal("-10.00"), false);
+  }
+
+  private Transaction persistTransaction(OffsetDateTime eventDate, boolean pending, boolean excludeFromTotals,
+      BigDecimal amount, boolean deleted) {
     Transaction transaction = new Transaction();
     transaction.setOwner(owner);
-    transaction.setType(TransactionTypeEnum.EXPENSE);
-    transaction.setAmount(new BigDecimal("-10.00"));
+    transaction.setType(amount.signum() >= 0 ? TransactionTypeEnum.INCOME : TransactionTypeEnum.EXPENSE);
+    transaction.setAmount(amount);
     transaction.setDescription("Test transaction");
     transaction.setEventDate(eventDate);
     transaction.setAccount(account);
@@ -80,7 +85,12 @@ class TransactionRepositoryTest {
     transaction.setSubcategory(subcategory);
     transaction.setPending(pending);
     transaction.setExcludeFromTotals(excludeFromTotals);
-    return entityManager.persistAndFlush(transaction);
+    Transaction persisted = entityManager.persistAndFlush(transaction);
+    if (deleted) {
+      transactionRepository.softDeleteById(persisted.getId());
+      entityManager.flush();
+    }
+    return persisted;
   }
 
   private Object[] currentPendingState(Long transactionId) {
@@ -185,5 +195,77 @@ class TransactionRepositoryTest {
 
     assertThat(result).extracting(Transaction::getId).containsExactlyInAnyOrder(pendingPast.getId(),
         pendingFuture.getId());
+  }
+
+  // --- getTransactionsTotalIncomesByMonth(IncludingPending) / getTransactionsTotalExpensesByMonth(IncludingPending) --
+
+  @Test
+  void getTransactionsTotalIncomesByMonthIncludingPending_includesAPendingTransactionThatTheExistingMethodExcludes() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("100.00"),
+        false);
+
+    List<Object[]> existingResult = transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
+    List<Object[]> includingPendingResult =
+        transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate);
+
+    assertThat(existingResult).isEmpty();
+    assertThat(includingPendingResult).hasSize(1);
+    assertThat((BigDecimal) includingPendingResult.get(0)[3]).isEqualByComparingTo("100.00");
+  }
+
+  @Test
+  void getTransactionsTotalExpensesByMonthIncludingPending_includesAPendingTransactionThatTheExistingMethodExcludes() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("-50.00"),
+        false);
+
+    List<Object[]> existingResult = transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
+    List<Object[]> includingPendingResult =
+        transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate);
+
+    assertThat(existingResult).isEmpty();
+    assertThat(includingPendingResult).hasSize(1);
+    assertThat((BigDecimal) includingPendingResult.get(0)[3]).isEqualByComparingTo("-50.00");
+  }
+
+  @Test
+  void getTransactionsTotalIncomesByMonthAndIncludingPendingVariant_bothExcludeATransferLeg() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, true, new BigDecimal("75.00"),
+        false); // transfer leg: excludeFromTotals=true, pending=false
+
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonth(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)).isEmpty();
+  }
+
+  @Test
+  void getTransactionsTotalExpensesByMonthAndIncludingPendingVariant_bothExcludeATransferLeg() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, true, new BigDecimal("-75.00"),
+        false); // transfer leg: excludeFromTotals=true, pending=false
+
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonth(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)).isEmpty();
+  }
+
+  @Test
+  void getTransactionsTotalIncomesByMonthAndIncludingPendingVariant_bothExcludeADeletedTransaction() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, false, new BigDecimal("60.00"),
+        true); // deleted, would otherwise be a normal counted income
+
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonth(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)).isEmpty();
+  }
+
+  @Test
+  void getTransactionsTotalExpensesByMonthAndIncludingPendingVariant_bothExcludeADeletedTransaction() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, false, new BigDecimal("-60.00"),
+        true); // deleted, would otherwise be a normal counted expense
+
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonth(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)).isEmpty();
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
@@ -26,12 +26,12 @@ import com.manuelfabri.expenses.model.User;
 /**
  * Note: assertions on the effect of {@code activateDuePendingTransactions} deliberately read back the
  * {@code pending}/{@code excludeFromTotals} columns via a scalar JPQL projection (see
- * {@link #currentPendingState(Long)}) rather than re-loading the {@code Transaction} entity itself. Loading the
- * entity fresh (e.g. via {@code entityManager.clear()} + {@code entityManager.find}) forces Hibernate to eagerly
- * re-resolve the {@code Account} association and evaluate its {@code accountBalance} {@code @Formula}, which is
- * hard-coded to the Liquibase column name ("initialbalance") and does not match the snake_case column
- * ("initial_balance") that this test's {@code ddl-auto: create-drop} schema generates — a pre-existing mismatch
- * unrelated to this test, so it's avoided rather than fixed here.
+ * {@link #currentPendingState(Long)}) rather than re-loading the {@code Transaction} entity itself, to keep this
+ * test decoupled from the {@code Account} association and its {@code accountBalance} {@code @Formula} (covered
+ * separately by {@code AccountRepositoryTest}). {@code Account.initialBalance} and {@code Transaction.excludeFromTotals}
+ * now carry explicit {@code @Column(name = ...)} mappings that match the Liquibase-managed physical column names
+ * ("initialbalance", "excludefromtotals") exactly, resolving what used to be a mismatch against the snake_case
+ * names this test's {@code ddl-auto: create-drop} schema previously generated for those two fields.
  */
 @DataJpaTest
 class TransactionRepositoryTest {

--- a/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
@@ -202,12 +202,13 @@ class TransactionRepositoryTest {
   @Test
   void getTransactionsTotalIncomesByMonthIncludingPending_includesAPendingTransactionThatTheExistingMethodExcludes() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("100.00"),
         false);
 
     List<Object[]> existingResult = transactionRepository.getTransactionsTotalIncomesByMonth(fromDate);
     List<Object[]> includingPendingResult =
-        transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate);
+        transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate);
 
     assertThat(existingResult).isEmpty();
     assertThat(includingPendingResult).hasSize(1);
@@ -217,12 +218,13 @@ class TransactionRepositoryTest {
   @Test
   void getTransactionsTotalExpensesByMonthIncludingPending_includesAPendingTransactionThatTheExistingMethodExcludes() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("-50.00"),
         false);
 
     List<Object[]> existingResult = transactionRepository.getTransactionsTotalExpensesByMonth(fromDate);
     List<Object[]> includingPendingResult =
-        transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate);
+        transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate);
 
     assertThat(existingResult).isEmpty();
     assertThat(includingPendingResult).hasSize(1);
@@ -232,40 +234,93 @@ class TransactionRepositoryTest {
   @Test
   void getTransactionsTotalIncomesByMonthAndIncludingPendingVariant_bothExcludeATransferLeg() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, true, new BigDecimal("75.00"),
         false); // transfer leg: excludeFromTotals=true, pending=false
 
     assertThat(transactionRepository.getTransactionsTotalIncomesByMonth(fromDate)).isEmpty();
-    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate)).isEmpty();
   }
 
   @Test
   void getTransactionsTotalExpensesByMonthAndIncludingPendingVariant_bothExcludeATransferLeg() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, true, new BigDecimal("-75.00"),
         false); // transfer leg: excludeFromTotals=true, pending=false
 
     assertThat(transactionRepository.getTransactionsTotalExpensesByMonth(fromDate)).isEmpty();
-    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate)).isEmpty();
   }
 
   @Test
   void getTransactionsTotalIncomesByMonthAndIncludingPendingVariant_bothExcludeADeletedTransaction() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, false, new BigDecimal("60.00"),
         true); // deleted, would otherwise be a normal counted income
 
     assertThat(transactionRepository.getTransactionsTotalIncomesByMonth(fromDate)).isEmpty();
-    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate)).isEmpty();
   }
 
   @Test
   void getTransactionsTotalExpensesByMonthAndIncludingPendingVariant_bothExcludeADeletedTransaction() {
     OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
     persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, false, new BigDecimal("-60.00"),
         true); // deleted, would otherwise be a normal counted expense
 
     assertThat(transactionRepository.getTransactionsTotalExpensesByMonth(fromDate)).isEmpty();
-    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate)).isEmpty();
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate)).isEmpty();
+  }
+
+  // --- getTransactionsTotal{Incomes,Expenses}ByMonthIncludingPending: new upper bound (toDate) clamping ------------
+
+  @Test
+  void getTransactionsTotalIncomesByMonthIncludingPending_excludesAPendingTransactionDatedAfterToDate() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("100.00"),
+        false); // pending, dated next month - beyond toDate
+
+    assertThat(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate)).isEmpty();
+  }
+
+  @Test
+  void getTransactionsTotalExpensesByMonthIncludingPending_excludesAPendingTransactionDatedAfterToDate() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("-100.00"),
+        false); // pending, dated next month - beyond toDate
+
+    assertThat(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate)).isEmpty();
+  }
+
+  @Test
+  void getTransactionsTotalIncomesByMonthIncludingPending_includesAPendingTransactionDatedWithinTheCurrentMonth() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 20, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("100.00"),
+        false); // pending, dated within the current month - within bounds
+
+    List<Object[]> result = transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(fromDate, toDate);
+
+    assertThat(result).hasSize(1);
+    assertThat((BigDecimal) result.get(0)[3]).isEqualByComparingTo("100.00");
+  }
+
+  @Test
+  void getTransactionsTotalExpensesByMonthIncludingPending_includesAPendingTransactionDatedWithinTheCurrentMonth() {
+    OffsetDateTime fromDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime toDate = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+    persistTransaction(OffsetDateTime.of(2024, 1, 20, 0, 0, 0, 0, ZoneOffset.UTC), true, true, new BigDecimal("-100.00"),
+        false); // pending, dated within the current month - within bounds
+
+    List<Object[]> result =
+        transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(fromDate, toDate);
+
+    assertThat(result).hasSize(1);
+    assertThat((BigDecimal) result.get(0)[3]).isEqualByComparingTo("-100.00");
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
+++ b/src/test/java/com/manuelfabri/expenses/repository/TransactionRepositoryTest.java
@@ -1,0 +1,189 @@
+package com.manuelfabri.expenses.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import com.manuelfabri.expenses.model.Account;
+import com.manuelfabri.expenses.model.Category;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.Subcategory;
+import com.manuelfabri.expenses.model.Transaction;
+import com.manuelfabri.expenses.model.TransactionTypeEnum;
+import com.manuelfabri.expenses.model.User;
+
+/**
+ * Note: assertions on the effect of {@code activateDuePendingTransactions} deliberately read back the
+ * {@code pending}/{@code excludeFromTotals} columns via a scalar JPQL projection (see
+ * {@link #currentPendingState(Long)}) rather than re-loading the {@code Transaction} entity itself. Loading the
+ * entity fresh (e.g. via {@code entityManager.clear()} + {@code entityManager.find}) forces Hibernate to eagerly
+ * re-resolve the {@code Account} association and evaluate its {@code accountBalance} {@code @Formula}, which is
+ * hard-coded to the Liquibase column name ("initialbalance") and does not match the snake_case column
+ * ("initial_balance") that this test's {@code ddl-auto: create-drop} schema generates — a pre-existing mismatch
+ * unrelated to this test, so it's avoided rather than fixed here.
+ */
+@DataJpaTest
+class TransactionRepositoryTest {
+
+  @Autowired
+  private TestEntityManager entityManager;
+  @Autowired
+  private TransactionRepository transactionRepository;
+
+  private User owner;
+  private Account account;
+  private Category category;
+  private Subcategory subcategory;
+
+  @BeforeEach
+  void setUp() {
+    owner = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
+    entityManager.persist(owner);
+    account = new Account(null, "Checking", CurrencyEnum.USD, owner);
+    entityManager.persist(account);
+    category = new Category(null, "Groceries", "icon", "#fff", owner, List.of());
+    category.setType(TransactionTypeEnum.EXPENSE);
+    entityManager.persist(category);
+    subcategory = new Subcategory(null, "Supermarket", category, List.of(), owner);
+    entityManager.persist(subcategory);
+
+    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(owner, null));
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private Transaction persistTransaction(OffsetDateTime eventDate, boolean pending, boolean excludeFromTotals) {
+    Transaction transaction = new Transaction();
+    transaction.setOwner(owner);
+    transaction.setType(TransactionTypeEnum.EXPENSE);
+    transaction.setAmount(new BigDecimal("-10.00"));
+    transaction.setDescription("Test transaction");
+    transaction.setEventDate(eventDate);
+    transaction.setAccount(account);
+    transaction.setCategory(category);
+    transaction.setSubcategory(subcategory);
+    transaction.setPending(pending);
+    transaction.setExcludeFromTotals(excludeFromTotals);
+    return entityManager.persistAndFlush(transaction);
+  }
+
+  private Object[] currentPendingState(Long transactionId) {
+    return (Object[]) entityManager.getEntityManager()
+        .createQuery("select t.pending, t.excludeFromTotals from transactions t where t.id = :id")
+        .setParameter("id", transactionId).getSingleResult();
+  }
+
+  // --- activateDuePendingTransactions ---------------------------------------------------------------------------
+
+  @Test
+  void activateDuePendingTransactions_activatesADuePendingTransaction() {
+    OffsetDateTime asOf = OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    Transaction duePending =
+        persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+
+    transactionRepository.activateDuePendingTransactions(asOf);
+
+    Object[] state = currentPendingState(duePending.getId());
+    assertThat((Boolean) state[0]).isFalse();
+    assertThat((Boolean) state[1]).isFalse();
+  }
+
+  @Test
+  void activateDuePendingTransactions_leavesAPermanentlyExcludedTransactionUntouched() {
+    OffsetDateTime asOf = OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    Transaction permanentlyExcluded =
+        persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), false, true);
+
+    transactionRepository.activateDuePendingTransactions(asOf);
+
+    Object[] state = currentPendingState(permanentlyExcluded.getId());
+    assertThat((Boolean) state[0]).isFalse();
+    assertThat((Boolean) state[1]).isTrue();
+  }
+
+  @Test
+  void activateDuePendingTransactions_leavesAFuturePendingTransactionUntouched() {
+    OffsetDateTime asOf = OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    Transaction futurePending =
+        persistTransaction(OffsetDateTime.of(2024, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+
+    transactionRepository.activateDuePendingTransactions(asOf);
+
+    Object[] state = currentPendingState(futurePending.getId());
+    assertThat((Boolean) state[0]).isTrue();
+    assertThat((Boolean) state[1]).isTrue();
+  }
+
+  @Test
+  void activateDuePendingTransactions_leavesASoftDeletedDuePendingTransactionUntouched() {
+    OffsetDateTime asOf = OffsetDateTime.of(2024, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    Transaction softDeletedDuePending =
+        persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    transactionRepository.softDeleteById(softDeletedDuePending.getId());
+    entityManager.flush();
+
+    transactionRepository.activateDuePendingTransactions(asOf);
+
+    Object[] state = currentPendingState(softDeletedDuePending.getId());
+    assertThat((Boolean) state[0]).isTrue();
+    assertThat((Boolean) state[1]).isTrue();
+  }
+
+  // --- findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse ----------------------------------------------
+
+  @Test
+  void findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse_returnsOnlyPendingTransactionsInRange() {
+    OffsetDateTime rangeStart = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime rangeEnd = OffsetDateTime.of(2024, 1, 31, 23, 59, 59, 0, ZoneOffset.UTC);
+
+    Transaction pendingInRange =
+        persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    persistTransaction(OffsetDateTime.of(2024, 2, 15, 0, 0, 0, 0, ZoneOffset.UTC), true, true); // pending, out of range
+    persistTransaction(OffsetDateTime.of(2024, 1, 15, 0, 0, 0, 0, ZoneOffset.UTC), false, false); // not pending
+    Transaction softDeletedPendingInRange =
+        persistTransaction(OffsetDateTime.of(2024, 1, 20, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    transactionRepository.softDeleteById(softDeletedPendingInRange.getId());
+    entityManager.flush();
+
+    List<Transaction> result =
+        transactionRepository.findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(owner, rangeStart, rangeEnd);
+
+    assertThat(result).extracting(Transaction::getId).containsExactly(pendingInRange.getId());
+  }
+
+  // --- findByOwnerAndPendingTrueAndDeletedFalse -----------------------------------------------------------------
+
+  @Test
+  void findByOwnerAndPendingTrueAndDeletedFalse_returnsAllPendingUndeletedTransactionsRegardlessOfDate() {
+    Transaction pendingPast =
+        persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    Transaction pendingFuture =
+        persistTransaction(OffsetDateTime.of(2024, 6, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), false, false); // not pending
+    Transaction softDeletedPending =
+        persistTransaction(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), true, true);
+    transactionRepository.softDeleteById(softDeletedPending.getId());
+    entityManager.flush();
+
+    List<Transaction> result = transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(owner);
+
+    assertThat(result).extracting(Transaction::getId).containsExactlyInAnyOrder(pendingPast.getId(),
+        pendingFuture.getId());
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/service/PendingTransactionActivationServiceTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/PendingTransactionActivationServiceTest.java
@@ -1,0 +1,43 @@
+package com.manuelfabri.expenses.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.manuelfabri.expenses.repository.TransactionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PendingTransactionActivationServiceTest {
+
+  @Mock
+  private TransactionRepository transactionRepository;
+
+  private PendingTransactionActivationService activationService;
+
+  @BeforeEach
+  void setUp() {
+    activationService = new PendingTransactionActivationService(transactionRepository);
+  }
+
+  @Test
+  void activateDueTransactions_callsRepositoryMethodWithCurrentTime() {
+    OffsetDateTime beforeCall = OffsetDateTime.now(ZoneOffset.UTC);
+
+    activationService.activateDueTransactions();
+
+    OffsetDateTime afterCall = OffsetDateTime.now(ZoneOffset.UTC);
+
+    ArgumentCaptor<OffsetDateTime> timeCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+    verify(transactionRepository).activateDuePendingTransactions(timeCaptor.capture());
+
+    OffsetDateTime capturedTime = timeCaptor.getValue();
+    assertThat(capturedTime).isAfterOrEqualTo(beforeCall).isBeforeOrEqualTo(afterCall);
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementationTest.java
@@ -1,27 +1,44 @@
 package com.manuelfabri.expenses.service.implementation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.modelmapper.ModelMapper;
 import org.modelmapper.config.Configuration.AccessLevel;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import com.manuelfabri.expenses.dto.TransactionDto;
 import com.manuelfabri.expenses.dto.TransactionRequestDto;
+import com.manuelfabri.expenses.exception.ResourceNotFoundException;
 import com.manuelfabri.expenses.model.Account;
 import com.manuelfabri.expenses.model.Category;
 import com.manuelfabri.expenses.model.CurrencyEnum;
@@ -35,9 +52,10 @@ import com.manuelfabri.expenses.repository.SubcategoryRepository;
 import com.manuelfabri.expenses.repository.TransactionRepository;
 
 /**
- * Focused on the sign-application call sites touched while extracting {@code TransactionTypeEnum.applySign} — not a
- * full test of every existing behavior in this service (transfers, paging/specifications, monthly summaries), which
- * remain part of the broader test-coverage gap tracked separately.
+ * Focused on the sign-application call sites touched while extracting {@code TransactionTypeEnum.applySign}, the
+ * pending formula (create/update/confirm/list), and that the pending exclusion is wired into the read paths — not a
+ * full test of every existing behavior in this service (paging/filtering edge cases beyond pending), which remains
+ * part of the broader test-coverage gap tracked separately.
  */
 @ExtendWith(MockitoExtension.class)
 class TransactionServiceImplementationTest {
@@ -54,8 +72,12 @@ class TransactionServiceImplementationTest {
   private TransactionServiceImplementation service;
   private User currentUser;
   private Account account;
+  private Account destinationAccount;
   private Category category;
   private Subcategory subcategory;
+  private Category transferCategory;
+  private Subcategory transferInSubcategory;
+  private Subcategory transferOutSubcategory;
 
   @BeforeEach
   void setUp() {
@@ -69,8 +91,12 @@ class TransactionServiceImplementationTest {
 
     currentUser = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
     account = new Account(10L, "Checking", CurrencyEnum.USD, currentUser);
+    destinationAccount = new Account(11L, "Savings", CurrencyEnum.USD, currentUser);
     category = new Category(20L, "Groceries", "icon", "#fff", currentUser, List.of());
     subcategory = new Subcategory(30L, "Supermarket", category, List.of(), currentUser);
+    transferCategory = new Category(40L, "Transfer", "icon", "#000", currentUser, List.of());
+    transferInSubcategory = new Subcategory(41L, "Transfer In", transferCategory, List.of(), currentUser);
+    transferOutSubcategory = new Subcategory(42L, "Transfer Out", transferCategory, List.of(), currentUser);
 
     SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
     securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(currentUser, null));
@@ -94,10 +120,39 @@ class TransactionServiceImplementationTest {
     return requestDto;
   }
 
+  private TransactionRequestDto requestDto(TransactionTypeEnum type, BigDecimal amount, OffsetDateTime eventDate,
+      boolean excludeFromTotals) {
+    TransactionRequestDto requestDto = requestDto(type, amount);
+    requestDto.setEventDate(eventDate);
+    requestDto.setExcludeFromTotals(excludeFromTotals);
+    return requestDto;
+  }
+
+  private TransactionRequestDto transferRequestDto(OffsetDateTime eventDate) {
+    TransactionRequestDto requestDto = new TransactionRequestDto();
+    requestDto.setType(TransactionTypeEnum.TRANSFER);
+    requestDto.setAmount(new BigDecimal("100.00"));
+    requestDto.setDescription("Move money");
+    requestDto.setAccountId(account.getId());
+    requestDto.setDestinationAccountId(destinationAccount.getId());
+    requestDto.setEventDate(eventDate);
+    return requestDto;
+  }
+
   private void stubRelatedEntities() {
     when(categoryRepository.findActiveById(category.getId())).thenReturn(Optional.of(category));
     when(subcategoryRepository.findActiveById(subcategory.getId())).thenReturn(Optional.of(subcategory));
     when(accountRepository.findActiveById(account.getId())).thenReturn(Optional.of(account));
+  }
+
+  private void stubTransferRelatedEntities() {
+    when(categoryRepository.findActiveByNameAndIsSystem("TRANSFER.CATEGORY")).thenReturn(Optional.of(transferCategory));
+    when(subcategoryRepository.findActiveByNameAndIsSystem("TRANSFER.IN.SUBCATEGORY"))
+        .thenReturn(Optional.of(transferInSubcategory));
+    when(subcategoryRepository.findActiveByNameAndIsSystem("TRANSFER.OUT.SUBCATEGORY"))
+        .thenReturn(Optional.of(transferOutSubcategory));
+    when(accountRepository.findActiveById(account.getId())).thenReturn(Optional.of(account));
+    when(accountRepository.findActiveById(destinationAccount.getId())).thenReturn(Optional.of(destinationAccount));
   }
 
   @Test
@@ -151,5 +206,268 @@ class TransactionServiceImplementationTest {
 
     assertThat(result.getAmount()).isEqualByComparingTo("-100.00");
     assertThat(result.getType()).isEqualTo(TransactionTypeEnum.EXPENSE);
+  }
+
+  // --- pending formula: createTransaction -------------------------------------------------------------------
+
+  @Test
+  void createTransaction_setsPendingTrue_forFutureDatedTransactionExcludedFromTotals() {
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto = requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), futureDate, true);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.createTransaction(requestDto);
+
+    assertThat(result.isPending()).isTrue();
+  }
+
+  @Test
+  void createTransaction_setsPendingFalse_forFutureDatedTransactionNotExcludedFromTotals() {
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto =
+        requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), futureDate, false);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.createTransaction(requestDto);
+
+    assertThat(result.isPending()).isFalse();
+  }
+
+  @Test
+  void createTransaction_setsPendingFalse_forPastDatedTransactionExcludedFromTotals() {
+    OffsetDateTime pastDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    TransactionRequestDto requestDto =
+        requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), pastDate, true);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.createTransaction(requestDto);
+
+    assertThat(result.isPending()).isFalse();
+  }
+
+  @Test
+  void createTransaction_setsPendingFalse_forFutureDatedTransfer_regardlessOfExcludeFromTotals() {
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto = transferRequestDto(futureDate);
+    stubTransferRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.createTransaction(requestDto);
+
+    assertThat(result.isPending()).isFalse();
+    assertThat(result.isExcludeFromTotals()).isTrue();
+  }
+
+  // --- pending formula: updateTransaction --------------------------------------------------------------------
+
+  private Transaction existingNonTransferTransaction() {
+    Transaction transaction = new Transaction();
+    transaction.setId(1L);
+    transaction.setType(TransactionTypeEnum.EXPENSE);
+    transaction.setAmount(new BigDecimal("-45.50"));
+    transaction.setEventDate(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    transaction.setAccount(account);
+    transaction.setCategory(category);
+    transaction.setSubcategory(subcategory);
+    return transaction;
+  }
+
+  @Test
+  void updateTransaction_setsPendingTrue_forFutureDatedTransactionExcludedFromTotals() {
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingNonTransferTransaction()));
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto = requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), futureDate, true);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.updateTransaction(1L, requestDto);
+
+    assertThat(result.isPending()).isTrue();
+  }
+
+  @Test
+  void updateTransaction_setsPendingFalse_forFutureDatedTransactionNotExcludedFromTotals() {
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingNonTransferTransaction()));
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto =
+        requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), futureDate, false);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.updateTransaction(1L, requestDto);
+
+    assertThat(result.isPending()).isFalse();
+  }
+
+  @Test
+  void updateTransaction_setsPendingFalse_forPastDatedTransactionExcludedFromTotals() {
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingNonTransferTransaction()));
+    OffsetDateTime pastDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    TransactionRequestDto requestDto =
+        requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), pastDate, true);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.updateTransaction(1L, requestDto);
+
+    assertThat(result.isPending()).isFalse();
+  }
+
+  @Test
+  void updateTransaction_setsPendingFalse_forFutureDatedTransfer() {
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingNonTransferTransaction()));
+    OffsetDateTime futureDate = OffsetDateTime.now(ZoneOffset.UTC).plusDays(10);
+    TransactionRequestDto requestDto = transferRequestDto(futureDate);
+    stubTransferRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.updateTransaction(1L, requestDto);
+
+    assertThat(result.isPending()).isFalse();
+    assertThat(result.isExcludeFromTotals()).isTrue();
+  }
+
+  @Test
+  void updateTransaction_flipsPendingToFalse_whenEventDateMovesFromFutureToPast() {
+    Transaction existingTransaction = existingNonTransferTransaction();
+    existingTransaction.setExcludeFromTotals(true);
+    existingTransaction.setPending(true);
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingTransaction));
+    OffsetDateTime pastDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    TransactionRequestDto requestDto =
+        requestDto(TransactionTypeEnum.EXPENSE, new BigDecimal("45.50"), pastDate, true);
+    stubRelatedEntities();
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.updateTransaction(1L, requestDto);
+
+    assertThat(result.isPending()).isFalse();
+  }
+
+  // --- confirm ------------------------------------------------------------------------------------------------
+
+  @Test
+  void confirm_clearsExcludeFromTotalsAndPending_andReturnsTheMappedTransaction() {
+    Transaction existingTransaction = existingNonTransferTransaction();
+    existingTransaction.setExcludeFromTotals(true);
+    existingTransaction.setPending(true);
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(existingTransaction));
+    when(transactionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    TransactionDto result = service.confirm(1L);
+
+    assertThat(result.isPending()).isFalse();
+    assertThat(result.isExcludeFromTotals()).isFalse();
+  }
+
+  @Test
+  void confirm_throwsResourceNotFound_whenTransactionMissing() {
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.confirm(1L)).isInstanceOf(ResourceNotFoundException.class);
+  }
+
+  // --- getPendingTransactions ----------------------------------------------------------------------------------
+
+  @Test
+  void getPendingTransactions_mapsAllTransactionsReturnedByTheRepository() {
+    Transaction firstPending = existingNonTransferTransaction();
+    firstPending.setId(1L);
+    Transaction secondPending = existingNonTransferTransaction();
+    secondPending.setId(2L);
+    when(transactionRepository.findAll(any(Specification.class))).thenReturn(List.of(firstPending, secondPending));
+
+    List<TransactionDto> result = service.getPendingTransactions();
+
+    assertThat(result).extracting(TransactionDto::getId).containsExactly(1L, 2L);
+  }
+
+  @Test
+  void getPendingTransactions_appliesIsPendingSpecification() {
+    ArgumentCaptor<Specification<Transaction>> specCaptor = ArgumentCaptor.forClass(Specification.class);
+    when(transactionRepository.findAll(specCaptor.capture())).thenReturn(List.of());
+
+    service.getPendingTransactions();
+
+    Root<Transaction> root = mockCriteriaRoot();
+    CriteriaBuilder criteriaBuilder = mockCriteriaBuilder();
+    specCaptor.getValue().toPredicate(root, mock(CriteriaQuery.class), criteriaBuilder);
+
+    verify(criteriaBuilder).isTrue(root.get("pending"));
+  }
+
+  // --- read paths exclude pending -------------------------------------------------------------------------------
+
+  @Test
+  void getPagedTransactions_appliesIsNotPendingSpecification() {
+    ArgumentCaptor<Specification<Transaction>> specCaptor = ArgumentCaptor.forClass(Specification.class);
+    when(transactionRepository.findAll(specCaptor.capture(), any(Pageable.class))).thenReturn(Page.empty());
+
+    service.getPagedTransactions(null, null, null, null, null, null, null, null, Pageable.unpaged());
+
+    Root<Transaction> root = mockCriteriaRoot();
+    CriteriaBuilder criteriaBuilder = mockCriteriaBuilder();
+    specCaptor.getValue().toPredicate(root, mock(CriteriaQuery.class), criteriaBuilder);
+
+    verify(criteriaBuilder).isFalse(root.get("pending"));
+  }
+
+  @Test
+  void getFilteredTotals_appliesIsNotPendingSpecification() {
+    ArgumentCaptor<Specification<Transaction>> specCaptor = ArgumentCaptor.forClass(Specification.class);
+    when(transactionRepository.findAll(specCaptor.capture())).thenReturn(List.of());
+
+    service.getFilteredTotals(null, null, null, null, null, null, null, null);
+
+    Root<Transaction> root = mockCriteriaRoot();
+    CriteriaBuilder criteriaBuilder = mockCriteriaBuilder();
+    specCaptor.getValue().toPredicate(root, mock(CriteriaQuery.class), criteriaBuilder);
+
+    verify(criteriaBuilder).isFalse(root.get("pending"));
+  }
+
+  @Test
+  void getMonthlyTransactions_usesThePendingFalseRepositoryMethod() {
+    OffsetDateTime startDate = OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
+    OffsetDateTime endDate = startDate.plusMonths(1).minusSeconds(1);
+    when(transactionRepository.findByOwnerAndEventDateBetweenAndPendingFalseAndDeletedFalse(currentUser, startDate,
+        endDate)).thenReturn(List.of(existingNonTransferTransaction()));
+
+    List<TransactionDto> result = service.getMonthlyTransactions(2024, 1);
+
+    assertThat(result).hasSize(1);
+    verify(transactionRepository).findByOwnerAndEventDateBetweenAndPendingFalseAndDeletedFalse(currentUser, startDate,
+        endDate);
+  }
+
+  // --- criteria API test doubles, used to verify the shape of composed Specifications without a real database ----
+
+  @SuppressWarnings("unchecked")
+  private Root<Transaction> mockCriteriaRoot() {
+    Map<String, Path<Object>> pathsByField = new HashMap<>();
+    Root<Transaction> root = mock(Root.class);
+    when(root.get(anyString())).thenAnswer(invocation -> {
+      String field = invocation.getArgument(0);
+      return pathsByField.computeIfAbsent(field, key -> {
+        Path<Object> path = mock(Path.class);
+        lenient().when(path.get(anyString())).thenReturn(path);
+        return path;
+      });
+    });
+    return root;
+  }
+
+  private CriteriaBuilder mockCriteriaBuilder() {
+    CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+    Predicate predicate = mock(Predicate.class);
+    lenient().when(criteriaBuilder.isFalse(any())).thenReturn(predicate);
+    lenient().when(criteriaBuilder.isTrue(any())).thenReturn(predicate);
+    lenient().when(criteriaBuilder.equal(any(), any())).thenReturn(predicate);
+    lenient().when(criteriaBuilder.or(any(Predicate.class), any(Predicate.class))).thenReturn(predicate);
+    lenient().when(criteriaBuilder.and(any(Predicate.class), any(Predicate.class))).thenReturn(predicate);
+    return criteriaBuilder;
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionServiceImplementationTest.java
@@ -370,6 +370,27 @@ class TransactionServiceImplementationTest {
     assertThatThrownBy(() -> service.confirm(1L)).isInstanceOf(ResourceNotFoundException.class);
   }
 
+  @Test
+  void confirm_rejectsATransferLeg_becauseItIsNotPending() {
+    Transaction transferLeg = existingNonTransferTransaction();
+    transferLeg.setType(TransactionTypeEnum.TRANSFER);
+    transferLeg.setExcludeFromTotals(true);
+    transferLeg.setPending(false);
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(transferLeg));
+
+    assertThatThrownBy(() -> service.confirm(1L)).isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void confirm_rejectsAPermanentlyExcludedTransaction_becauseItIsNotPending() {
+    Transaction permanentlyExcluded = existingNonTransferTransaction();
+    permanentlyExcluded.setExcludeFromTotals(true);
+    permanentlyExcluded.setPending(false);
+    when(transactionRepository.findActiveById(1L)).thenReturn(Optional.of(permanentlyExcluded));
+
+    assertThatThrownBy(() -> service.confirm(1L)).isInstanceOf(IllegalArgumentException.class);
+  }
+
   // --- getPendingTransactions ----------------------------------------------------------------------------------
 
   @Test

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
@@ -1,0 +1,132 @@
+package com.manuelfabri.expenses.service.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import com.manuelfabri.expenses.model.Account;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.User;
+import com.manuelfabri.expenses.repository.AccountRepository;
+import com.manuelfabri.expenses.repository.TransactionRepository;
+
+/**
+ * Focused on {@code getBalancesByCurrency()} and its two overloads. The no-arg overload was rewritten to sum each
+ * active account's {@code accountBalance} (the {@code @Formula}-computed running balance, which already includes
+ * {@code initialBalance}) instead of delegating to a repository query over transactions alone - see the class under
+ * test and {@code Account.accountBalance}. The year/month overloads are unchanged (still period net-change queries
+ * delegated straight to {@link TransactionRepository}), so this file also regression-tests that they keep doing
+ * that and never touch {@link AccountRepository}.
+ */
+@ExtendWith(MockitoExtension.class)
+class TransactionStatisticsServiceImplementationTest {
+
+  @Mock
+  private TransactionRepository transactionRepository;
+  @Mock
+  private AccountRepository accountRepository;
+
+  private TransactionStatisticsServiceImplementation service;
+  private User owner;
+
+  private void createService() {
+    service = new TransactionStatisticsServiceImplementation(transactionRepository, accountRepository);
+  }
+
+  private Account account(Long id, CurrencyEnum currency, String accountBalance) {
+    if (owner == null) {
+      owner = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
+    }
+    Account account = new Account(id, "Account " + id, currency, owner);
+    account.setAccountBalance(new BigDecimal(accountBalance));
+    return account;
+  }
+
+  // --- getBalancesByCurrency() (no-arg) ---------------------------------------------------------------------------
+
+  @Test
+  void getBalancesByCurrency_sumsActiveAccountsGroupedByCurrency() {
+    createService();
+    Account first = account(1L, CurrencyEnum.USD, "100.00");
+    Account second = account(2L, CurrencyEnum.USD, "50.00");
+    when(accountRepository.findActive()).thenReturn(List.of(first, second));
+
+    Map<CurrencyEnum, BigDecimal> result = service.getBalancesByCurrency();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(CurrencyEnum.USD)).isEqualByComparingTo("150.00");
+  }
+
+  @Test
+  void getBalancesByCurrency_includesAnAccountWithOnlyInitialBalanceAndNoTransactions() {
+    createService();
+    Account zeroActivityAccount = account(1L, CurrencyEnum.USD, "250.00");
+    when(accountRepository.findActive()).thenReturn(List.of(zeroActivityAccount));
+
+    Map<CurrencyEnum, BigDecimal> result = service.getBalancesByCurrency();
+
+    assertThat(result.get(CurrencyEnum.USD)).isEqualByComparingTo("250.00");
+  }
+
+  @Test
+  void getBalancesByCurrency_producesSeparateEntriesForDifferentCurrencies() {
+    createService();
+    Account usdAccount = account(1L, CurrencyEnum.USD, "100.00");
+    Account eurAccount = account(2L, CurrencyEnum.EUR, "75.00");
+    Account arsAccount = account(3L, CurrencyEnum.ARS, "500.00");
+    when(accountRepository.findActive()).thenReturn(List.of(usdAccount, eurAccount, arsAccount));
+
+    Map<CurrencyEnum, BigDecimal> result = service.getBalancesByCurrency();
+
+    assertThat(result).hasSize(3);
+    assertThat(result.get(CurrencyEnum.USD)).isEqualByComparingTo("100.00");
+    assertThat(result.get(CurrencyEnum.EUR)).isEqualByComparingTo("75.00");
+    assertThat(result.get(CurrencyEnum.ARS)).isEqualByComparingTo("500.00");
+  }
+
+  @Test
+  void getBalancesByCurrency_doesNotDelegateToTheTransactionRepository() {
+    createService();
+    when(accountRepository.findActive()).thenReturn(List.of(account(1L, CurrencyEnum.USD, "10.00")));
+
+    service.getBalancesByCurrency();
+
+    verifyNoInteractions(transactionRepository);
+  }
+
+  // --- getBalancesByCurrency(year) / (year, month) - unchanged regression coverage ---------------------------------
+
+  @Test
+  void getBalancesByCurrencyForYear_stillDelegatesToTheTransactionRepository_andNeverTouchesAccountRepository() {
+    createService();
+    List<Object[]> repositoryResult = List.<Object[]>of(new Object[] {CurrencyEnum.USD, new BigDecimal("42.00")});
+    when(transactionRepository.getBalancesByCurrency(2024)).thenReturn(repositoryResult);
+
+    Map<CurrencyEnum, BigDecimal> result = service.getBalancesByCurrency(2024);
+
+    assertThat(result.get(CurrencyEnum.USD)).isEqualByComparingTo("42.00");
+    verify(transactionRepository).getBalancesByCurrency(2024);
+    verifyNoInteractions(accountRepository);
+  }
+
+  @Test
+  void getBalancesByCurrencyForYearAndMonth_stillDelegatesToTheTransactionRepository_andNeverTouchesAccountRepository() {
+    createService();
+    List<Object[]> repositoryResult = List.<Object[]>of(new Object[] {CurrencyEnum.EUR, new BigDecimal("15.00")});
+    when(transactionRepository.getBalancesByCurrency(2024, 3)).thenReturn(repositoryResult);
+
+    Map<CurrencyEnum, BigDecimal> result = service.getBalancesByCurrency(2024, 3);
+
+    assertThat(result.get(CurrencyEnum.EUR)).isEqualByComparingTo("15.00");
+    verify(transactionRepository).getBalancesByCurrency(2024, 3);
+    verifyNoInteractions(accountRepository);
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
@@ -1,17 +1,21 @@
 package com.manuelfabri.expenses.service.implementation;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import com.manuelfabri.expenses.dto.MonthlyBalanceSummaryDto;
 import com.manuelfabri.expenses.model.Account;
 import com.manuelfabri.expenses.model.CurrencyEnum;
 import com.manuelfabri.expenses.model.User;
@@ -128,5 +132,87 @@ class TransactionStatisticsServiceImplementationTest {
     assertThat(result.get(CurrencyEnum.EUR)).isEqualByComparingTo("15.00");
     verify(transactionRepository).getBalancesByCurrency(2024, 3);
     verifyNoInteractions(accountRepository);
+  }
+
+  // --- getMonthlyHistory(months, includePending) ------------------------------------------------------------------
+
+  @Test
+  void getMonthlyHistory_withIncludePendingTrue_includesAPendingTransactionsAmountInTheCurrentMonthsBucket() {
+    createService();
+    OffsetDateTime now = OffsetDateTime.now();
+    Object[] currentMonthIncomeRow =
+        new Object[] {now.getYear(), now.getMonthValue(), CurrencyEnum.USD, new BigDecimal("120.00")};
+
+    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class)))
+        .thenReturn(List.<Object[]>of(currentMonthIncomeRow));
+    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class)))
+        .thenReturn(List.<Object[]>of());
+
+    List<MonthlyBalanceSummaryDto> result = service.getMonthlyHistory(1, true);
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getYear()).isEqualTo(now.getYear());
+    assertThat(result.get(0).getMonth()).isEqualTo(now.getMonthValue());
+    assertThat(result.get(0).getIncomes()).isEqualByComparingTo("120.00");
+    verify(transactionRepository).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class));
+    verify(transactionRepository, never()).getTransactionsTotalIncomesByMonth(any(OffsetDateTime.class));
+  }
+
+  @Test
+  void getMonthlyHistory_withIncludePendingFalse_andTheLegacyOverload_produceIdenticalResults_excludingThePendingAmount() {
+    createService();
+    List<Object[]> incomeResults =
+        List.<Object[]>of(new Object[] {2026, 8, CurrencyEnum.USD, new BigDecimal("300.00")});
+    List<Object[]> expenseResults =
+        List.<Object[]>of(new Object[] {2026, 8, CurrencyEnum.USD, new BigDecimal("-45.00")});
+    when(transactionRepository.getTransactionsTotalIncomesByMonth(any(OffsetDateTime.class))).thenReturn(incomeResults);
+    when(transactionRepository.getTransactionsTotalExpensesByMonth(any(OffsetDateTime.class)))
+        .thenReturn(expenseResults);
+
+    List<MonthlyBalanceSummaryDto> explicitFalseResult = service.getMonthlyHistory(3, false);
+    List<MonthlyBalanceSummaryDto> legacyResult = service.getMonthlyHistory(3);
+
+    assertThat(legacyResult).hasSize(1);
+    assertThat(explicitFalseResult).hasSize(1);
+    assertThat(legacyResult.get(0).getYear()).isEqualTo(explicitFalseResult.get(0).getYear());
+    assertThat(legacyResult.get(0).getMonth()).isEqualTo(explicitFalseResult.get(0).getMonth());
+    assertThat(legacyResult.get(0).getIncomes()).isEqualByComparingTo(explicitFalseResult.get(0).getIncomes());
+    assertThat(legacyResult.get(0).getExpenses()).isEqualByComparingTo(explicitFalseResult.get(0).getExpenses());
+    assertThat(explicitFalseResult.get(0).getIncomes()).isEqualByComparingTo("300.00"); // the pending amount never
+                                                                                          // surfaces here
+    verify(transactionRepository, never()).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class));
+    verify(transactionRepository, never())
+        .getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class));
+  }
+
+  @Test
+  void getMonthlyHistory_withIncludePendingTrue_aRowForALaterMonthNeverAltersAnEarlierRequestedMonthsBucket() {
+    // Sanity check on the "no upper bound needed" reasoning behind the *IncludingPending repository queries:
+    // because those queries only add a lower bound (fromDate) and pending transactions are always dated "now" or
+    // later, a pending transaction due in a month beyond the current one can only ever create its OWN year/month
+    // bucket - it can never retroactively change the totals already computed for an earlier, in-range month.
+    createService();
+    OffsetDateTime now = OffsetDateTime.now();
+    int laterYear = now.getMonthValue() == 12 ? now.getYear() + 1 : now.getYear();
+    int laterMonth = now.getMonthValue() == 12 ? 1 : now.getMonthValue() + 1;
+
+    Object[] currentMonthRow = new Object[] {now.getYear(), now.getMonthValue(), CurrencyEnum.USD, new BigDecimal("200.00")};
+    Object[] laterMonthRow = new Object[] {laterYear, laterMonth, CurrencyEnum.USD, new BigDecimal("999.00")};
+
+    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class)))
+        .thenReturn(List.<Object[]>of(currentMonthRow, laterMonthRow));
+    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class)))
+        .thenReturn(List.of());
+
+    List<MonthlyBalanceSummaryDto> result = service.getMonthlyHistory(3, true);
+
+    assertThat(result).hasSize(2);
+    MonthlyBalanceSummaryDto currentBucket = result.stream()
+        .filter(dto -> dto.getMonth() == now.getMonthValue() && dto.getYear() == now.getYear()).findFirst()
+        .orElseThrow();
+    MonthlyBalanceSummaryDto laterBucket = result.stream()
+        .filter(dto -> dto.getMonth() == laterMonth && dto.getYear() == laterYear).findFirst().orElseThrow();
+    assertThat(currentBucket.getIncomes()).isEqualByComparingTo("200.00");
+    assertThat(laterBucket.getIncomes()).isEqualByComparingTo("999.00");
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/TransactionStatisticsServiceImplementationTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import com.manuelfabri.expenses.dto.MonthlyBalanceSummaryDto;
@@ -143,10 +144,10 @@ class TransactionStatisticsServiceImplementationTest {
     Object[] currentMonthIncomeRow =
         new Object[] {now.getYear(), now.getMonthValue(), CurrencyEnum.USD, new BigDecimal("120.00")};
 
-    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class)))
-        .thenReturn(List.<Object[]>of(currentMonthIncomeRow));
-    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class)))
-        .thenReturn(List.<Object[]>of());
+    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.<Object[]>of(currentMonthIncomeRow));
+    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.<Object[]>of());
 
     List<MonthlyBalanceSummaryDto> result = service.getMonthlyHistory(1, true);
 
@@ -154,7 +155,8 @@ class TransactionStatisticsServiceImplementationTest {
     assertThat(result.get(0).getYear()).isEqualTo(now.getYear());
     assertThat(result.get(0).getMonth()).isEqualTo(now.getMonthValue());
     assertThat(result.get(0).getIncomes()).isEqualByComparingTo("120.00");
-    verify(transactionRepository).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class));
+    verify(transactionRepository).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class));
     verify(transactionRepository, never()).getTransactionsTotalIncomesByMonth(any(OffsetDateTime.class));
   }
 
@@ -180,39 +182,61 @@ class TransactionStatisticsServiceImplementationTest {
     assertThat(legacyResult.get(0).getExpenses()).isEqualByComparingTo(explicitFalseResult.get(0).getExpenses());
     assertThat(explicitFalseResult.get(0).getIncomes()).isEqualByComparingTo("300.00"); // the pending amount never
                                                                                           // surfaces here
-    verify(transactionRepository, never()).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class));
-    verify(transactionRepository, never())
-        .getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class));
+    verify(transactionRepository, never()).getTransactionsTotalIncomesByMonthIncludingPending(
+        any(OffsetDateTime.class), any(OffsetDateTime.class));
+    verify(transactionRepository, never()).getTransactionsTotalExpensesByMonthIncludingPending(
+        any(OffsetDateTime.class), any(OffsetDateTime.class));
   }
 
   @Test
-  void getMonthlyHistory_withIncludePendingTrue_aRowForALaterMonthNeverAltersAnEarlierRequestedMonthsBucket() {
-    // Sanity check on the "no upper bound needed" reasoning behind the *IncludingPending repository queries:
-    // because those queries only add a lower bound (fromDate) and pending transactions are always dated "now" or
-    // later, a pending transaction due in a month beyond the current one can only ever create its OWN year/month
-    // bucket - it can never retroactively change the totals already computed for an earlier, in-range month.
+  void getMonthlyHistory_withIncludePendingTrue_passesAnUpperBoundClampedToTheEndOfTheCurrentMonth() {
+    // Product decision: includePending=true must only ever affect the CURRENT month's totals, never a future
+    // month beyond it. The service is responsible for computing and passing that upper bound (end of the current
+    // calendar month) into the *IncludingPending repository queries.
+    createService();
+    OffsetDateTime now = OffsetDateTime.now();
+
+    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.of());
+    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.of());
+
+    service.getMonthlyHistory(3, true);
+
+    ArgumentCaptor<OffsetDateTime> toDateCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+    verify(transactionRepository).getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class),
+        toDateCaptor.capture());
+    OffsetDateTime toDate = toDateCaptor.getValue();
+
+    assertThat(toDate.getYear()).isEqualTo(now.getYear());
+    assertThat(toDate.getMonthValue()).isEqualTo(now.getMonthValue());
+    assertThat(toDate.getDayOfMonth()).isEqualTo(now.toLocalDate().lengthOfMonth());
+    assertThat(toDate).isAfterOrEqualTo(now);
+  }
+
+  @Test
+  void getMonthlyHistory_withIncludePendingTrue_aRowForALaterMonthDoesNotAppearInTheResponse() {
+    // Product decision: a pending transaction dated beyond the current month must be clamped out entirely by the
+    // repository query's new upper bound - it must not create its own bucket in the response.
     createService();
     OffsetDateTime now = OffsetDateTime.now();
     int laterYear = now.getMonthValue() == 12 ? now.getYear() + 1 : now.getYear();
     int laterMonth = now.getMonthValue() == 12 ? 1 : now.getMonthValue() + 1;
 
     Object[] currentMonthRow = new Object[] {now.getYear(), now.getMonthValue(), CurrencyEnum.USD, new BigDecimal("200.00")};
-    Object[] laterMonthRow = new Object[] {laterYear, laterMonth, CurrencyEnum.USD, new BigDecimal("999.00")};
+    // The repository query itself excludes later-month rows via the new toDate bound; the mock here simulates
+    // that already-filtered result to verify the service doesn't need to do any additional filtering itself.
 
-    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class)))
-        .thenReturn(List.<Object[]>of(currentMonthRow, laterMonthRow));
-    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class)))
-        .thenReturn(List.of());
+    when(transactionRepository.getTransactionsTotalIncomesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.<Object[]>of(currentMonthRow));
+    when(transactionRepository.getTransactionsTotalExpensesByMonthIncludingPending(any(OffsetDateTime.class),
+        any(OffsetDateTime.class))).thenReturn(List.of());
 
     List<MonthlyBalanceSummaryDto> result = service.getMonthlyHistory(3, true);
 
-    assertThat(result).hasSize(2);
-    MonthlyBalanceSummaryDto currentBucket = result.stream()
-        .filter(dto -> dto.getMonth() == now.getMonthValue() && dto.getYear() == now.getYear()).findFirst()
-        .orElseThrow();
-    MonthlyBalanceSummaryDto laterBucket = result.stream()
-        .filter(dto -> dto.getMonth() == laterMonth && dto.getYear() == laterYear).findFirst().orElseThrow();
-    assertThat(currentBucket.getIncomes()).isEqualByComparingTo("200.00");
-    assertThat(laterBucket.getIncomes()).isEqualByComparingTo("999.00");
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getYear()).isEqualTo(now.getYear());
+    assertThat(result.get(0).getMonth()).isEqualTo(now.getMonthValue());
+    assertThat(result.stream().anyMatch(dto -> dto.getMonth() == laterMonth && dto.getYear() == laterYear)).isFalse();
   }
 }

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
@@ -1,0 +1,397 @@
+package com.manuelfabri.expenses.service.implementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.modelmapper.ModelMapper;
+import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionGroupDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionItemDto;
+import com.manuelfabri.expenses.dto.UpcomingTransactionsResponseDto;
+import com.manuelfabri.expenses.model.Account;
+import com.manuelfabri.expenses.model.Category;
+import com.manuelfabri.expenses.model.CurrencyEnum;
+import com.manuelfabri.expenses.model.RecurrenceFrequencyEnum;
+import com.manuelfabri.expenses.model.RecurrenceStatusEnum;
+import com.manuelfabri.expenses.model.RecurrentTransaction;
+import com.manuelfabri.expenses.model.SourceTypeEnum;
+import com.manuelfabri.expenses.model.Transaction;
+import com.manuelfabri.expenses.model.TransactionTypeEnum;
+import com.manuelfabri.expenses.model.User;
+import com.manuelfabri.expenses.repository.RecurrentTransactionRepository;
+import com.manuelfabri.expenses.repository.TransactionRepository;
+import com.manuelfabri.expenses.service.RecurrenceDateCalculator;
+
+@ExtendWith(MockitoExtension.class)
+class UpcomingTransactionServiceImplementationTest {
+
+  @Mock
+  private RecurrentTransactionRepository recurrentTransactionRepository;
+  @Mock
+  private TransactionRepository transactionRepository;
+  @Mock
+  private RecurrenceDateCalculator dateCalculator;
+
+  private UpcomingTransactionServiceImplementation service;
+  private User currentUser;
+  private Account usdAccount;
+  private Account eurAccount;
+  private Category expenseCategory;
+  private Category incomeCategory;
+  private LocalDate today;
+  private LocalDate endOfMonth;
+
+  @BeforeEach
+  void setUp() {
+    service = new UpcomingTransactionServiceImplementation(recurrentTransactionRepository, transactionRepository,
+        dateCalculator, new ModelMapper());
+
+    currentUser = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
+    usdAccount = new Account(10L, "Checking USD", CurrencyEnum.USD, currentUser);
+    eurAccount = new Account(11L, "Checking EUR", CurrencyEnum.EUR, currentUser);
+    expenseCategory = new Category(20L, "Subscriptions", "icon-expense", "#f00", currentUser, List.of());
+    expenseCategory.setType(TransactionTypeEnum.EXPENSE);
+    incomeCategory = new Category(21L, "Salary", "icon-income", "#0f0", currentUser, List.of());
+    incomeCategory.setType(TransactionTypeEnum.INCOME);
+
+    today = LocalDate.now(ZoneOffset.UTC);
+    endOfMonth = YearMonth.from(today).atEndOfMonth();
+
+    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
+    securityContext.setAuthentication(new UsernamePasswordAuthenticationToken(currentUser, null));
+    SecurityContextHolder.setContext(securityContext);
+  }
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  private RecurrentTransaction recurrence(Long id, TransactionTypeEnum type, BigDecimal amount, Account account,
+      Category category, RecurrenceStatusEnum status) {
+    RecurrentTransaction recurrence = new RecurrentTransaction();
+    recurrence.setId(id);
+    recurrence.setType(type);
+    recurrence.setAmount(amount);
+    recurrence.setDescription("Recurrence " + id);
+    recurrence.setAccount(account);
+    recurrence.setCategory(category);
+    recurrence.setFrequency(RecurrenceFrequencyEnum.INTERVAL_DAYS);
+    recurrence.setIntervalDays(30);
+    recurrence.setStartDate(OffsetDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+    recurrence.setStatus(status);
+    return recurrence;
+  }
+
+  private Transaction pendingTransaction(Long id, TransactionTypeEnum type, BigDecimal signedAmount, Account account,
+      Category category, OffsetDateTime eventDate) {
+    Transaction transaction = new Transaction();
+    transaction.setId(id);
+    transaction.setType(type);
+    transaction.setAmount(signedAmount);
+    transaction.setDescription("Transaction " + id);
+    transaction.setAccount(account);
+    transaction.setCategory(category);
+    transaction.setEventDate(eventDate);
+    transaction.setPending(true);
+    return transaction;
+  }
+
+  private void stubNoOneTimeTransactions() {
+    when(transactionRepository.findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(eq(currentUser), any(),
+        any())).thenReturn(List.of());
+  }
+
+  // ---------------------------------------------------------------------
+  // getUpcomingTransactions: ACTIVE-only vs getProgrammedTransactions: ACTIVE+PAUSED
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getUpcomingTransactions_excludesPausedRecurrences_includesOnlyActive() {
+    RecurrentTransaction activeRecurrence =
+        recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount, expenseCategory,
+            RecurrenceStatusEnum.ACTIVE);
+    RecurrentTransaction pausedRecurrence =
+        recurrence(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("20.00"), usdAccount, expenseCategory,
+            RecurrenceStatusEnum.PAUSED);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(activeRecurrence, pausedRecurrence));
+    when(dateCalculator.nextDueDate(activeRecurrence)).thenReturn(Optional.of(today));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+    assertThat(result.getExpenses().get(0).getItems()).extracting(UpcomingTransactionItemDto::getSourceId)
+        .containsExactly(1L);
+  }
+
+  @Test
+  void getProgrammedTransactions_includesBothActiveAndPausedRecurrences() {
+    RecurrentTransaction activeRecurrence =
+        recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount, expenseCategory,
+            RecurrenceStatusEnum.ACTIVE);
+    RecurrentTransaction pausedRecurrence =
+        recurrence(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("20.00"), usdAccount, expenseCategory,
+            RecurrenceStatusEnum.PAUSED);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(activeRecurrence, pausedRecurrence));
+    when(dateCalculator.nextDueDate(activeRecurrence)).thenReturn(Optional.of(today.plusDays(5)));
+    when(dateCalculator.nextDueDate(pausedRecurrence)).thenReturn(Optional.of(today.plusDays(10)));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).extracting(UpcomingTransactionItemDto::getSourceId).containsExactly(1L, 2L);
+  }
+
+  // ---------------------------------------------------------------------
+  // getUpcomingTransactions: window boundary
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getUpcomingTransactions_includesRecurrence_whenDueDateIsExactlyToday() {
+    RecurrentTransaction dueToday = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(dueToday));
+    when(dateCalculator.nextDueDate(dueToday)).thenReturn(Optional.of(today));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+  }
+
+  @Test
+  void getUpcomingTransactions_includesRecurrence_whenDueDateIsExactlyEndOfMonth() {
+    RecurrentTransaction dueAtEndOfMonth = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(dueAtEndOfMonth));
+    when(dateCalculator.nextDueDate(dueAtEndOfMonth)).thenReturn(Optional.of(endOfMonth));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+  }
+
+  @Test
+  void getUpcomingTransactions_excludesRecurrence_whenDueDateIsBeforeToday() {
+    RecurrentTransaction overdue = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(overdue));
+    when(dateCalculator.nextDueDate(overdue)).thenReturn(Optional.of(today.minusDays(1)));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+  }
+
+  @Test
+  void getUpcomingTransactions_excludesRecurrence_whenDueDateIsAfterEndOfMonth() {
+    RecurrentTransaction nextMonth = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(nextMonth));
+    when(dateCalculator.nextDueDate(nextMonth)).thenReturn(Optional.of(endOfMonth.plusDays(1)));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+  }
+
+  @Test
+  void getUpcomingTransactions_excludesRecurrence_whenCalculatorReturnsEmpty() {
+    RecurrentTransaction expired = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(expired));
+    when(dateCalculator.nextDueDate(expired)).thenReturn(Optional.empty());
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------
+  // getProgrammedTransactions: unbounded
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getProgrammedTransactions_includesRecurrencesDueWellBeyondCurrentMonth() {
+    RecurrentTransaction farFuture = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(farFuture));
+    when(dateCalculator.nextDueDate(farFuture)).thenReturn(Optional.of(today.plusYears(1)));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+  }
+
+  // ---------------------------------------------------------------------
+  // Amount signing: fromRecurrence signs, fromTransaction uses as-is
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getUpcomingTransactions_signsTheRecurrenceAmount_butUsesTheTransactionAmountAsIs() {
+    RecurrentTransaction expenseRecurrence = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("50.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(expenseRecurrence));
+    when(dateCalculator.nextDueDate(expenseRecurrence)).thenReturn(Optional.of(today));
+
+    OffsetDateTime tomorrow = today.plusDays(1).atStartOfDay().atOffset(ZoneOffset.UTC);
+    Transaction alreadySignedTransaction =
+        pendingTransaction(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("-75.00"), usdAccount, expenseCategory,
+            tomorrow);
+    when(transactionRepository.findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(eq(currentUser), any(),
+        any())).thenReturn(List.of(alreadySignedTransaction));
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    List<UpcomingTransactionItemDto> items = result.getExpenses().get(0).getItems();
+    UpcomingTransactionItemDto recurrenceItem =
+        items.stream().filter(item -> item.getSourceType() == SourceTypeEnum.RECURRING).findFirst().orElseThrow();
+    UpcomingTransactionItemDto transactionItem =
+        items.stream().filter(item -> item.getSourceType() == SourceTypeEnum.ONE_TIME).findFirst().orElseThrow();
+
+    // Recurrence amount is stored unsigned (50.00) and must be re-signed to -50.00 for an EXPENSE.
+    assertThat(recurrenceItem.getSignedAmount()).isEqualByComparingTo("-50.00");
+    // Transaction amount is already signed at creation time and must be used exactly as stored.
+    assertThat(transactionItem.getSignedAmount()).isEqualByComparingTo("-75.00");
+  }
+
+  // ---------------------------------------------------------------------
+  // Merge / group / sort / total
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getUpcomingTransactions_groupsByCurrency_sortsWithinGroupByDate_andSumsTotal() {
+    RecurrentTransaction usdRecurrence = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(usdRecurrence));
+    when(dateCalculator.nextDueDate(usdRecurrence)).thenReturn(Optional.of(today.plusDays(2)));
+
+    Transaction usdTransactionEarlier = pendingTransaction(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("-15.00"),
+        usdAccount, expenseCategory, today.atStartOfDay().atOffset(ZoneOffset.UTC));
+    Transaction eurTransaction = pendingTransaction(3L, TransactionTypeEnum.EXPENSE, new BigDecimal("-40.00"),
+        eurAccount, expenseCategory, today.plusDays(1).atStartOfDay().atOffset(ZoneOffset.UTC));
+    when(transactionRepository.findByOwnerAndPendingTrueAndEventDateBetweenAndDeletedFalse(eq(currentUser), any(),
+        any())).thenReturn(List.of(usdTransactionEarlier, eurTransaction));
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).hasSize(2);
+    UpcomingTransactionGroupDto usdGroup = result.getExpenses().stream()
+        .filter(group -> group.getCurrency().equals("USD")).findFirst().orElseThrow();
+    UpcomingTransactionGroupDto eurGroup = result.getExpenses().stream()
+        .filter(group -> group.getCurrency().equals("EUR")).findFirst().orElseThrow();
+
+    // USD group: transaction (today) then recurrence (today+2), sorted ascending by date.
+    assertThat(usdGroup.getItems()).extracting(UpcomingTransactionItemDto::getSourceId).containsExactly(2L, 1L);
+    assertThat(usdGroup.getTotal()).isEqualByComparingTo("-45.00");
+
+    assertThat(eurGroup.getItems()).extracting(UpcomingTransactionItemDto::getSourceId).containsExactly(3L);
+    assertThat(eurGroup.getTotal()).isEqualByComparingTo("-40.00");
+  }
+
+  @Test
+  void getUpcomingTransactions_splitsExpensesAndIncomesIntoSeparateResponseLists() {
+    RecurrentTransaction expenseRecurrence = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    RecurrentTransaction incomeRecurrence = recurrence(2L, TransactionTypeEnum.INCOME, new BigDecimal("1000.00"),
+        usdAccount, incomeCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(expenseRecurrence, incomeRecurrence));
+    when(dateCalculator.nextDueDate(expenseRecurrence)).thenReturn(Optional.of(today));
+    when(dateCalculator.nextDueDate(incomeRecurrence)).thenReturn(Optional.of(today));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+    assertThat(result.getExpenses().get(0).getItems()).extracting(UpcomingTransactionItemDto::getSourceId)
+        .containsExactly(1L);
+    assertThat(result.getIncomes()).hasSize(1);
+    assertThat(result.getIncomes().get(0).getItems()).extracting(UpcomingTransactionItemDto::getSourceId)
+        .containsExactly(2L);
+  }
+
+  @Test
+  void getProgrammedTransactions_interleavesRecurringAndOneTimeItemsSortedByDate() {
+    RecurrentTransaction laterRecurrence = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(laterRecurrence));
+    when(dateCalculator.nextDueDate(laterRecurrence)).thenReturn(Optional.of(today.plusDays(10)));
+
+    Transaction earlierTransaction = pendingTransaction(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("-15.00"),
+        usdAccount, expenseCategory, today.plusDays(3).atStartOfDay().atOffset(ZoneOffset.UTC));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser))
+        .thenReturn(List.of(earlierTransaction));
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).extracting(UpcomingTransactionItemDto::getSourceId).containsExactly(2L, 1L);
+  }
+
+  // ---------------------------------------------------------------------
+  // Transfers never appear
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getUpcomingTransactions_excludesTransferTypeRecurrences_fromBothBuckets() {
+    RecurrentTransaction transferRecurrence = recurrence(1L, TransactionTypeEnum.TRANSFER, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(transferRecurrence));
+    when(dateCalculator.nextDueDate(transferRecurrence)).thenReturn(Optional.of(today));
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+    assertThat(result.getIncomes()).isEmpty();
+  }
+
+  @Test
+  void getProgrammedTransactions_excludesTransferTypeRecurrences_fromBothBuckets() {
+    RecurrentTransaction transferRecurrence = recurrence(1L, TransactionTypeEnum.TRANSFER, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(transferRecurrence));
+    when(dateCalculator.nextDueDate(transferRecurrence)).thenReturn(Optional.of(today));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+    assertThat(result.getIncomes()).isEmpty();
+  }
+
+  @Test
+  void getProgrammedTransactions_excludesCancelledRecurrences_evenIfRepositoryReturnsOne() {
+    RecurrentTransaction cancelledRecurrence = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.CANCELLED);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(cancelledRecurrence));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+  }
+}

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
@@ -394,4 +394,70 @@ class UpcomingTransactionServiceImplementationTest {
 
     assertThat(result.getExpenses()).isEmpty();
   }
+
+  // ---------------------------------------------------------------------
+  // getProgrammedTransactions: ended recurrences (ACTIVE/PAUSED, no more due dates) are still included
+  // ---------------------------------------------------------------------
+
+  @Test
+  void getProgrammedTransactions_includesEndedActiveRecurrence_withNullDate() {
+    RecurrentTransaction endedActive = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(endedActive));
+    when(dateCalculator.nextDueDate(endedActive)).thenReturn(Optional.empty());
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+    assertThat(result.getExpenses().get(0).getSourceId()).isEqualTo(1L);
+    assertThat(result.getExpenses().get(0).getDate()).isNull();
+  }
+
+  @Test
+  void getProgrammedTransactions_includesEndedPausedRecurrence_withNullDate() {
+    RecurrentTransaction endedPaused = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"),
+        usdAccount, expenseCategory, RecurrenceStatusEnum.PAUSED);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(endedPaused));
+    when(dateCalculator.nextDueDate(endedPaused)).thenReturn(Optional.empty());
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).hasSize(1);
+    assertThat(result.getExpenses().get(0).getSourceId()).isEqualTo(1L);
+    assertThat(result.getExpenses().get(0).getDate()).isNull();
+  }
+
+  @Test
+  void getUpcomingTransactions_stillExcludesEndedRecurrence_regressionForBoundedDashboardView() {
+    RecurrentTransaction ended = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("30.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(ended));
+    when(dateCalculator.nextDueDate(ended)).thenReturn(Optional.empty());
+    stubNoOneTimeTransactions();
+
+    UpcomingTransactionsResponseDto result = service.getUpcomingTransactions();
+
+    assertThat(result.getExpenses()).isEmpty();
+  }
+
+  @Test
+  void getProgrammedTransactions_sortsNullDatedEndedRecurrences_last() {
+    RecurrentTransaction dated = recurrence(1L, TransactionTypeEnum.EXPENSE, new BigDecimal("10.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    RecurrentTransaction ended = recurrence(2L, TransactionTypeEnum.EXPENSE, new BigDecimal("20.00"), usdAccount,
+        expenseCategory, RecurrenceStatusEnum.ACTIVE);
+    // Repository order deliberately puts the ended (null-date) recurrence before the dated one, so the assertion
+    // proves the sort — not incidental insertion order — puts it last.
+    when(recurrentTransactionRepository.findActiveVisible()).thenReturn(List.of(ended, dated));
+    when(dateCalculator.nextDueDate(ended)).thenReturn(Optional.empty());
+    when(dateCalculator.nextDueDate(dated)).thenReturn(Optional.of(today.plusDays(5)));
+    when(transactionRepository.findByOwnerAndPendingTrueAndDeletedFalse(currentUser)).thenReturn(List.of());
+
+    ProgrammedTransactionsDto result = service.getProgrammedTransactions();
+
+    assertThat(result.getExpenses()).extracting(UpcomingTransactionItemDto::getSourceId).containsExactly(1L, 2L);
+    assertThat(result.getExpenses().get(1).getDate()).isNull();
+  }
 }

--- a/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
+++ b/src/test/java/com/manuelfabri/expenses/service/implementation/UpcomingTransactionServiceImplementationTest.java
@@ -21,7 +21,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.modelmapper.ModelMapper;
 import com.manuelfabri.expenses.dto.ProgrammedTransactionsDto;
 import com.manuelfabri.expenses.dto.UpcomingTransactionGroupDto;
 import com.manuelfabri.expenses.dto.UpcomingTransactionItemDto;
@@ -62,7 +61,7 @@ class UpcomingTransactionServiceImplementationTest {
   @BeforeEach
   void setUp() {
     service = new UpcomingTransactionServiceImplementation(recurrentTransactionRepository, transactionRepository,
-        dateCalculator, new ModelMapper());
+        dateCalculator);
 
     currentUser = new User("owner-1", "owner@example.com", "owner", "Owner", "One", List.of());
     usdAccount = new Account(10L, "Checking USD", CurrencyEnum.USD, currentUser);


### PR DESCRIPTION
## Summary
- Derived `pending` flag on one-time transactions: future-dated + excluded transactions are auto-excluded from totals until their date arrives, then a nightly job activates them (or the user can Confirm early).
- New `GET /summary/upcoming-transactions` (dashboard, bounded) and `GET /summary/programmed-transactions` (management view, unbounded) merging recurring + pending one-time items.
- `PATCH /transaction/{id}/confirm`, `GET /transaction/pending`.
- Fix: `Account.accountBalance` and `/summary`'s "current balance" now correctly include each account's initial balance (previously transaction-only), and no longer drop transfer legs.
- New: optional `includePending` param on `/summary/monthly-history`, clamped to the current month, backward compatible (defaults false).

## Flagged, not fixed
`application.yml`'s Hibernate naming-strategy override looks like a no-op (same bug pattern as two already-fixed config keys in that file). Could affect audit columns on every table if `ddl-auto=validate` is live in prod — needs checking against the real Spring Cloud Config server content, which wasn't accessible during this work.

## Test plan
- [x] Full suite: 154/154 passing
- [x] Diff coverage: 99.4%
- [ ] Manual verification against a running frontend (paired PR: manufabri91/expensapp-web#feat/upcoming-transactions)